### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: "CI"
 on:
 - push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     # The type of runner that the job will run on


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/cvxrisk/security/code-scanning/2](https://github.com/cvxgrp/cvxrisk/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the provided steps, the workflow likely only needs `contents: read` to access the repository's contents. If additional permissions are required for specific actions, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
