### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   marimo:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: cvxgrp/.github/actions/environment@v2.2.8
@@ -14,6 +16,8 @@ jobs:
 
   pdoc:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: cvxgrp/.github/actions/environment@v2.2.8
@@ -22,6 +26,8 @@ jobs:
 
   test:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: cvxgrp/.github/actions/environment@v2.2.8
@@ -30,6 +36,8 @@ jobs:
 
   jupyter:
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: "Build the virtual environment for ${{ github.repository }}"
         uses: cvxgrp/.github/actions/environment@v2.2.8


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/cvxrisk/security/code-scanning/1](https://github.com/cvxgrp/cvxrisk/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to each job (`marimo`, `pdoc`, `test`, and `jupyter`) that currently lacks one. Since these jobs do not appear to require write access, we will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures that the `GITHUB_TOKEN` is restricted to read-only access unless explicitly needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
