### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,4 +1,6 @@
 name: DEVCONTAINER
+permissions:
+  contents: read
 
 # Building these containers is expensive initially, so only run on changes to devcontainer files
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/cvxgrp/cvxrisk/security/code-scanning/11](https://github.com/cvxgrp/cvxrisk/security/code-scanning/11)

To fix the problem, the workflow file `.github/workflows/devcontainer.yml` should be updated to explicitly set the `permissions:` key either at the root level (to apply to all jobs without their own block) or within the particular job (`configuration`). Since the `devcontainer-build` job already specifies its own permissions, the most comprehensive and future-proof solution is to add a root-level `permissions:` block with minimal access, such as `contents: read`, which is usually all that is required for jobs like these unless steps involve writing to the repo, packages, etc. 

Edit `.github/workflows/devcontainer.yml` to add a top-level `permissions:` key, ideally immediately after the `name:` and before the `on:` block. Set it to:

```yaml
permissions:
  contents: read
```

This ensures that, unless a job specifies its own permissions, it gets only read-level access to repository contents, thus following the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
