### PR TITLE
feat: upgrade cvx-linalg to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,13 @@ smaller set of factors:
 
 ```python
 import numpy as np
-import polars as pl
 from cvx.risk.factor import FactorModel
 from cvx.linalg import pca
 
 # Create some sample returns data
 a = 100
 m = 25
-returns = pl.DataFrame(np.random.randn(a, m))
+returns = np.random.randn(a, m)
 
 # Compute principal components (deterministic using a fixed seed for reproducibility)
 np.random.seed(0)
@@ -118,9 +117,9 @@ factors = pca(returns, n_components=10)
 # Create and update the factor model
 model = FactorModel(assets=m, k=10)
 model.update(
-    cov=factors.cov.to_numpy(),
-    exposure=factors.exposure.to_numpy(),
-    idiosyncratic_risk=factors.idiosyncratic.std().to_numpy().ravel(),
+    cov=factors.cov,
+    exposure=factors.exposure,
+    idiosyncratic_risk=factors.idiosyncratic.std(axis=0, ddof=1),
     lower_assets=np.zeros(m),
     upper_assets=np.ones(m),
     lower_factors=-0.1*np.ones(10),

--- a/book/marimo/factormodel.py
+++ b/book/marimo/factormodel.py
@@ -45,7 +45,7 @@ def _():
 
 @app.cell
 def _(returns):
-    factors = pca(returns=returns, n_components=10)
+    factors = pca(returns=returns.to_numpy(), n_components=10)
     return (factors,)
 
 
@@ -55,9 +55,9 @@ def _(factors, returns):
 
     # update the model parameters
     model.update(
-        cov=factors.cov.to_numpy(),
-        exposure=factors.exposure.to_numpy(),
-        idiosyncratic_risk=factors.idiosyncratic.std().to_numpy().ravel(),
+        cov=factors.cov,
+        exposure=factors.exposure,
+        idiosyncratic_risk=factors.idiosyncratic.std(axis=0, ddof=1),
         lower_assets=np.zeros(model.assets),
         upper_assets=np.ones(model.assets),
         lower_factors=-0.1 * np.ones(model.k),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.11"
 # List of core dependencies required for the package to function
 dependencies = [
     "clarabel>=0.11.1",    # Conic interior-point solver (replaces cvxpy-base)
-    "cvx-linalg>=0.2.0",   # Linear algebra utilities (provides cvx.linalg)
+    "cvx-linalg>=0.3.0",   # Linear algebra utilities (provides cvx.linalg)
     "numpy>=2.3.0",        # Numerical computing library for array operations
     #"pandas>=3.0.3",       # Data manipulation and analysis library
     "scipy>=1.17.1",       # Scientific computing (sparse matrix support)

--- a/tests/risk/factor/test_factor.py
+++ b/tests/risk/factor/test_factor.py
@@ -45,14 +45,14 @@ def test_timeseries_model(returns: pl.DataFrame) -> None:
 
     """
     # Here we compute the factors and regress the returns on them
-    factors = principal_components(returns=returns, n_components=10)
+    factors = principal_components(returns=returns.to_numpy(), n_components=10)
 
     model = FactorModel(assets=25, k=10)
 
     model.update(
-        cov=factors.cov.to_numpy(),
-        exposure=factors.exposure.to_numpy(),
-        idiosyncratic_risk=factors.idiosyncratic.std().to_numpy().ravel(),
+        cov=factors.cov,
+        exposure=factors.exposure,
+        idiosyncratic_risk=factors.idiosyncratic.std(axis=0, ddof=1),
         lower_assets=np.zeros(20),
         upper_assets=np.ones(20),
         lower_factors=np.zeros(10),

--- a/tests/risk/test_integration.py
+++ b/tests/risk/test_integration.py
@@ -89,7 +89,7 @@ def test_factor_model_optimization():
     model.update(
         cov=factors.cov,
         exposure=factors.exposure,
-        idiosyncratic_risk=factors.idiosyncratic.std(axis=0),
+        idiosyncratic_risk=factors.idiosyncratic.std(axis=0, ddof=1),
         lower_assets=np.zeros(n_assets),
         upper_assets=np.ones(n_assets),
         lower_factors=-0.1 * np.ones(n_factors),

--- a/tests/risk/test_integration.py
+++ b/tests/risk/test_integration.py
@@ -15,7 +15,6 @@ and as examples of how to use the package in practice.
 """
 
 import numpy as np
-import polars as pl
 from cvx.linalg import pca, rand_cov
 
 from cvx.core.variable import Variable
@@ -81,16 +80,16 @@ def test_factor_model_optimization():
 
     # Generate random returns data
     n_periods = 100
-    returns = pl.DataFrame(rng.standard_normal((n_periods, n_assets)))
+    returns = rng.standard_normal((n_periods, n_assets))
 
     # Compute principal components
     factors = pca(returns, n_components=n_factors)
 
     # Update the factor model
     model.update(
-        cov=factors.cov.to_numpy(),
-        exposure=factors.exposure.to_numpy(),
-        idiosyncratic_risk=factors.idiosyncratic.std().to_numpy().ravel(),
+        cov=factors.cov,
+        exposure=factors.exposure,
+        idiosyncratic_risk=factors.idiosyncratic.std(axis=0),
         lower_assets=np.zeros(n_assets),
         upper_assets=np.ones(n_assets),
         lower_factors=-0.1 * np.ones(n_factors),

--- a/uv.lock
+++ b/uv.lock
@@ -134,15 +134,14 @@ wheels = [
 
 [[package]]
 name = "cvx-linalg"
-version = "0.2.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
-    { name = "polars" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/14/63b5797a9263f27397efd3bd9a9f53c43ddf925481690e712558b89440e7/cvx_linalg-0.2.0.tar.gz", hash = "sha256:406b07fba57ebe08a22458a0f3f59986e603de0fec414154a0b6506c917cae3e", size = 13029, upload-time = "2026-05-13T03:36:42.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/cc/31e46ac1a9668168b88bf13d91a7289bb25743e698988c86715005b8a854/cvx_linalg-0.3.0.tar.gz", hash = "sha256:9a9598bf12d84ace08af9caff9ac8d25de56aca0d515eae3fb71b9502702ecd0", size = 11861, upload-time = "2026-05-13T06:16:40.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/f9/e0fb0875344c5c663ee919ad848be6b0bd981bccf1566da5423e08097e6a/cvx_linalg-0.2.0-py3-none-any.whl", hash = "sha256:160f9d791c9d77878420390f843f2c10af1f1a350d9294741268a0765faad0bf", size = 10926, upload-time = "2026-05-13T03:36:41Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5c/224b1fdaf6821d648b067ef9fc7c1cabf55676d7cfbeff1e39bd8092df9d/cvx_linalg-0.3.0-py3-none-any.whl", hash = "sha256:2a68860ff1a8da4496e74c86f1ec6441b2ee7a956e96ca427b69ba191e18421c", size = 8486, upload-time = "2026-05-13T06:16:39.579Z" },
 ]
 
 [[package]]
@@ -208,7 +207,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "clarabel", specifier = ">=0.11.1" },
-    { name = "cvx-linalg", specifier = ">=0.2.0" },
+    { name = "cvx-linalg", specifier = ">=0.3.0" },
     { name = "numpy", specifier = ">=2.3.0" },
     { name = "scipy", specifier = ">=1.17.1" },
 ]


### PR DESCRIPTION
## Summary

- Bumps `cvx-linalg` dependency from `>=0.2.0` to `>=0.3.0`
- Updates tests to pass numpy arrays into `pca()` — 0.3.0 dropped Polars support and is pure-numpy
- Removes `.to_numpy()` calls on PCA result fields (already `ndarray` in 0.3.0)
- Uses `std(axis=0, ddof=1)` for idiosyncratic risk to preserve sample-std behaviour that Polars `.std()` provided by default

## Test plan

- [ ] All 30 tests pass with 100% coverage (`make test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)