### PR TITLE
Replace pandas/cvxsimulator with polars/jquantstats in marimo notebooks

### DIFF
--- a/book/marimo/demo.py
+++ b/book/marimo/demo.py
@@ -3,6 +3,7 @@
 #     "marimo==0.18.4",
 #     "pandas",
 #     "polars",
+#     "pyarrow",
 #     "jquantstats",
 #     "cvxrisk"
 # ]

--- a/book/marimo/demo.py
+++ b/book/marimo/demo.py
@@ -3,7 +3,7 @@
 #     "marimo==0.18.4",
 #     "pandas",
 #     "polars",
-#     "cvxsimulator",
+#     "jquantstats",
 #     "cvxrisk"
 # ]
 #
@@ -11,7 +11,7 @@
 # cvxrisk = { path = "../..", editable=true }
 # ///
 
-"""Demo of the risk and simulator packages."""
+"""Demo of the risk packages with jquantstats performance reporting."""
 
 import marimo
 
@@ -19,24 +19,18 @@ __generated_with = "0.13.15"
 app = marimo.App(width="medium")
 
 with app.setup:
+    import jquantstats as jqs
     import marimo as mo
     import numpy as np
-    import pandas as pd
     import polars as pl
-    from cvx.simulator import Builder
 
     from cvx.core.variable import Variable
+    from cvx.risk import __version__ as risk_version
     from cvx.risk.portfolio import minrisk_problem
     from cvx.risk.sample import SampleCovariance
 
-    pd.options.plotting.backend = "plotly"
-
-    from cvx.simulator import __version__ as simulator_version
-
-    from cvx.risk import __version__ as risk_version
-
     print(f"Risk version: {risk_version}")
-    print(f"Simulator version: {simulator_version}")
+    print(f"jquantstats version: {jqs.__version__}")
 
 
 @app.cell
@@ -46,72 +40,94 @@ def _():
 
     prices = prices.to_pandas().set_index("date")
 
-    # Estimate a series of historic covariance matrices
+    # Compute returns and EWM covariance (requires pandas)
     returns = prices.pct_change().dropna(axis=0, how="all")
-    return prices, returns
-
-
-@app.cell
-def _(prices, returns):
     cov = returns.ewm(com=60, min_periods=100).cov().dropna(axis=0, how="all")
     start = cov.index[0][0]
-
-    # Establish a risk model
-    _risk_model = SampleCovariance(num=20)
-
-    # Perform the backtest
-    _builder = Builder(prices=prices.truncate(before=start), initial_aum=1e6)
-
-    _w = Variable(len(_builder.prices.columns))
-    _problem = minrisk_problem(_risk_model, _w)
-
-    for _t, _state in _builder:
-        _risk_model.update(
-            cov=cov.loc[_t[-1]].values,
-            lower_assets=np.zeros(20),
-            upper_assets=np.ones(20),
-        )
-
-        # don't reconstruct the problem in every iteration!
-        _problem.solve()
-
-        _builder.weights = _w.value
-        _builder.aum = _state.aum
-
-    _portfolio = _builder.build()
-
-    _portfolio.nav.plot()
-    return (start,)
+    return prices, returns, cov, start
 
 
 @app.cell
-def _(prices, returns, start):
+def _(cov, returns, start):
+    # Minimum-risk backtest using SampleCovariance
+    cov_dates = set(cov.index.get_level_values(0))
+    returns_bt = returns.loc[start:]
+
+    _risk_model = SampleCovariance(num=20)
+    _w = Variable(20)
+    _problem = minrisk_problem(_risk_model, _w)
+    _current_w = None
+
+    _port_rets = []
+    for _date in returns_bt.index:
+        if _date in cov_dates:
+            _risk_model.update(
+                cov=cov.loc[_date].values,
+                lower_assets=np.zeros(20),
+                upper_assets=np.ones(20),
+            )
+            _problem.solve()
+            _current_w = _w.value.copy()
+
+        if _current_w is not None:
+            _port_rets.append(float(returns_bt.loc[_date].values @ _current_w))
+
+    _returns_pl = pl.DataFrame(
+        {
+            "Date": returns_bt.index[-len(_port_rets) :].to_list(),
+            "SampleCovariance": _port_rets,
+        }
+    )
+    data_sc = jqs.Data.from_returns(_returns_pl, date_col="Date")
+    print(data_sc.stats.sharpe())
+    return (data_sc,)
+
+
+@app.cell
+def _(data_sc):
+    data_sc.plots.snapshot()
+
+
+@app.cell
+def _(returns, start):
     from cvx.risk.cvar import CVar
 
+    _returns_bt = returns.loc[start:]
+
     _risk_model = CVar(alpha=0.80, n=40, m=20)
-
-    # Perform the backtest
-    _builder = Builder(prices=prices.truncate(before=start), initial_aum=1e6)
-
-    _w = Variable(len(_builder.prices.columns))
+    _w = Variable(20)
     _problem = minrisk_problem(_risk_model, _w)
+    _current_w = None
 
-    for _t, _state in _builder:
-        _risk_model.update(
-            returns=returns.truncate(after=_t[-1]).tail(40).values,
-            lower_assets=np.zeros(20),
-            upper_assets=np.ones(20),
-        )
+    _port_rets = []
+    for _i, _date in enumerate(_returns_bt.index):
+        _hist = _returns_bt.iloc[: _i + 1].tail(40)
+        if len(_hist) == 40:
+            _risk_model.update(
+                returns=_hist.values,
+                lower_assets=np.zeros(20),
+                upper_assets=np.ones(20),
+            )
+            _problem.solve()
+            _current_w = _w.value.copy()
 
-        # don't reconstruct the problem in every iteration!
-        _problem.solve()
+        if _current_w is not None:
+            _port_rets.append(float(_returns_bt.iloc[_i].values @ _current_w))
 
-        _builder.weights = _w.value
-        _builder.aum = _state.aum
+    _returns_pl = pl.DataFrame(
+        {
+            "Date": _returns_bt.index[-len(_port_rets) :].to_list(),
+            "CVar": _port_rets,
+        }
+    )
+    data_cvar = jqs.Data.from_returns(_returns_pl, date_col="Date")
+    print(data_cvar.stats.sharpe())
+    return (data_cvar,)
 
-    _portfolio = _builder.build()
-    _portfolio.nav.plot()
-    return
+
+@app.cell
+def _(data_cvar):
+    data_cvar.plots.snapshot()
 
 
 if __name__ == "__main__":

--- a/book/marimo/factormodel.py
+++ b/book/marimo/factormodel.py
@@ -2,7 +2,6 @@
 # dependencies = [
 #     "marimo==0.18.4",
 #     "numpy",
-#     "pandas",
 #     "polars",
 #     "cvxrisk",
 #     "cvx-linalg",
@@ -23,7 +22,6 @@ app = marimo.App(width="medium")
 with app.setup:
     import marimo as mo
     import numpy as np
-    import pandas as pd
     import polars as pl
     from cvx.linalg import pca
 
@@ -37,11 +35,11 @@ def _():
     # Load some historic stock prices
     prices = pl.read_csv(str(mo.notebook_location() / "public" / "stock_prices.csv"), try_parse_dates=True)
 
-    prices = prices.to_pandas().set_index("date")
+    asset_cols = [c for c in prices.columns if c != "date"]
 
-    # Estimate a series of historic covariance matrices
-    returns = pl.from_pandas(prices.pct_change().dropna(axis=0, how="all").reset_index(drop=True))
-    return prices, returns
+    # Compute percentage returns in polars
+    returns = prices.select(pl.col(asset_cols).pct_change()).drop_nulls()
+    return prices, returns, asset_cols
 
 
 @app.cell
@@ -73,14 +71,14 @@ def _(factors, returns):
 
 
 @app.cell
-def _(model, prices):
+def _(asset_cols, model):
     w = Variable(model.assets)
     y = Variable(model.k)
 
     problem = minrisk_problem(model, w, y=y)
     problem.solve()
 
-    print(pd.Series(data=w.value, index=prices.columns))
+    print(pl.DataFrame({"asset": asset_cols, "weight": w.value}))
     print(model.estimate(w.value))
 
     # check the solution

--- a/book/marimo/large.py
+++ b/book/marimo/large.py
@@ -2,7 +2,6 @@
 # dependencies = [
 #     "marimo==0.18.4",
 #     "numpy",
-#     "pandas",
 #     "cvxrisk"
 # ]
 #
@@ -22,7 +21,6 @@ with app.setup:
 
     import marimo as mo
     import numpy as np
-    import pandas as pd
 
     from cvx.core.variable import Variable
     from cvx.risk.factor import FactorModel
@@ -42,34 +40,23 @@ def _random():
 
     def random_weights(assets):
         """Construct a vector of non-negative random weights. Their sum shall be 1."""
-        # Get some random weights
-        weights = pd.Series(index=assets, data=rng.random(len(assets)))
-        return weights / weights.sum()
+        w = rng.random(len(assets))
+        return w / w.sum()
 
     def random_factors(t, n=2, const_factor=True):
         """Construct N random factor time series for T timestamps."""
-        factors = pd.DataFrame(
-            index=range(1, t + 1),
-            columns=[f"F{i}" for i in range(n)],
-            data=rng.standard_normal((t, n)),
-        )
-        # add the constant factor
+        data = rng.standard_normal((t, n))
         if const_factor:
-            factors["const"] = 1
-        return factors
+            data = np.column_stack([data, np.ones(t)])
+        return data
 
     def random_beta(assets, factors):
         """Construct a random exposure matrix."""
-        data = rng.standard_normal((factors.shape[1], len(assets)))
-        return pd.DataFrame(columns=assets, index=factors.columns, data=data)
+        return rng.standard_normal((factors.shape[1], len(assets)))
 
     def random_noise(frame):
         """Construct a frame of random noise with exactly the same dimensions as the input frame."""
-        return pd.DataFrame(
-            columns=frame.columns,
-            index=frame.index,
-            data=rng.standard_normal((frame.shape[0], frame.shape[1])),
-        )
+        return rng.standard_normal(frame.shape)
 
     def random_assets(num):
         """Construct a vector of random assets."""
@@ -99,7 +86,7 @@ def _(beta, factors, random_noise):
 
 @app.cell
 def _(ret):
-    triangle = FactorModel(assets=len(ret.columns), k=100)
+    triangle = FactorModel(assets=ret.shape[1], k=100)
     return (triangle,)
 
 
@@ -109,9 +96,9 @@ def _(beta, factors, ret, triangle):
     y = Variable(100)
     _problem = minrisk_problem(triangle, w, y=y)
     triangle.update(
-        exposure=beta.values,
-        cov=factors.cov().values,
-        idiosyncratic_risk=pd.DataFrame(data=ret - factors @ beta, index=ret.index, columns=ret.columns).std().values,
+        exposure=beta,
+        cov=np.cov(factors.T),
+        idiosyncratic_risk=(ret - factors @ beta).std(axis=0),
         lower_assets=np.zeros(1000),
         upper_assets=np.ones(1000),
         lower_factors=-0.1 * np.ones(100),
@@ -125,11 +112,9 @@ def _(beta, factors, ret, triangle, w, y):
     for _i in range(1):
         _problem = minrisk_problem(triangle, w, y=y)
         triangle.update(
-            exposure=beta.values,
-            cov=factors.cov().values,
-            idiosyncratic_risk=pd.DataFrame(data=ret - factors @ beta, index=ret.index, columns=ret.columns)
-            .std()
-            .values,
+            exposure=beta,
+            cov=np.cov(factors.T),
+            idiosyncratic_risk=(ret - factors @ beta).std(axis=0),
             lower_assets=np.zeros(1000),
             upper_assets=np.ones(1000),
             lower_factors=-0.1 * np.ones(100),

--- a/book/marimo/tilting.py
+++ b/book/marimo/tilting.py
@@ -2,7 +2,7 @@
 # dependencies = [
 #     "marimo==0.18.4",
 #     "numpy",
-#     "pandas",
+#     "polars",
 #     "cvx-linalg",
 #     "cvxrisk"
 # ]
@@ -21,7 +21,7 @@ app = marimo.App(width="medium")
 with app.setup:
     import marimo as mo
     import numpy as np
-    import pandas as pd
+    import polars as pl
     from cvx.linalg import rand_cov
 
     from cvx.core.variable import Variable
@@ -97,10 +97,10 @@ def _():
 def _():
     # Let's start without the tilting constraint
     assets = ["A", "B", "C", "D", "E"]
-    s = pd.DataFrame(index=assets, columns=assets, data=rand_cov(len(assets)))
+    s = pl.DataFrame(dict(zip(assets, rand_cov(len(assets)).T, strict=False)))
 
     # those are the market weights for our 5 markets
-    w_sp = pd.Series(index=assets, data=[0.1, 0.2, 0.3, 0.1, 0.3])
+    w_sp = pl.Series(values=[0.1, 0.2, 0.3, 0.1, 0.3])
 
     # the Variable for the weights
     weights = Variable(len(assets))
@@ -110,18 +110,18 @@ def _():
     riskmodel.update(cov=s.to_numpy(), lower_assets=np.zeros(len(assets)), upper_assets=np.ones(len(assets)))
 
     # the tilting vector
-    v = pd.Series(index=assets, data=[0.1, 0.1, 0.5, 0.0, 0.5])
+    v = pl.Series(values=[0.1, 0.1, 0.5, 0.0, 0.5])
     return assets, riskmodel, v, w_sp, weights
 
 
 @app.cell
 def _(assets, riskmodel, w_sp, weights):
     # without the tilting constraint. We reproduce (as predicted) w_sp.
-    problem = minrisk_problem(riskmodel=riskmodel, weights=weights, base=w_sp.values, constraints=[])
+    problem = minrisk_problem(riskmodel=riskmodel, weights=weights, base=w_sp.to_numpy(), constraints=[])
 
     problem.solve()
 
-    solution = pd.Series(index=assets, data=weights.value)
+    solution = pl.DataFrame({"asset": assets, "weight": weights.value})
     print(solution)
     return
 
@@ -131,16 +131,16 @@ def _(assets, riskmodel, v, w_sp, weights):
     # Now we specify the tilting constraint: v @ w == 0.5 as (a, lb, ub) with lb == ub
     constraints = [(v.to_numpy(), 0.5, 0.5)]
     # We inject the constraints
-    problem_tilt = minrisk_problem(riskmodel=riskmodel, weights=weights, base=w_sp.values, constraints=constraints)
+    problem_tilt = minrisk_problem(riskmodel=riskmodel, weights=weights, base=w_sp.to_numpy(), constraints=constraints)
 
     problem_tilt.solve()
 
     # The solution is different from the previous problem
-    solution_tilt = pd.Series(index=assets, data=weights.value)
+    solution_tilt = pl.DataFrame({"asset": assets, "weight": weights.value})
     print(solution_tilt)
     # We check whether the tilting constraint is respected
     print("Tilting value. Should be close to 0.5:")
-    print(solution_tilt.to_numpy() @ v.to_numpy())
+    print(weights.value @ v.to_numpy())
     return
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/cvxgrp/cvxrisk"
 [dependency-groups]
 # Development dependencies for testing, linting, and documentation
 dev = [
-    "cvxsimulator>=1.4.5", # Simulation framework for portfolio optimization
+    "jquantstats>=0.6.5",  # Portfolio performance analysis and reporting
     "marimo>=0.23.6",      # Interactive notebook environment
     "polars>=1.34.0",      # Fast DataFrame library (alternative to pandas)
     "plotly>=6.5",

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -2,8 +2,6 @@
 
 import importlib.metadata
 
-import cvx.simulator
-
 import cvx.risk
 
 
@@ -22,17 +20,3 @@ def test_versions() -> None:
 
     # Print the versions for debugging purposes
     print(f"Package version: {expected_version}")
-
-
-def test_version_simulator():
-    """Test the versioning of the simulator module.
-
-    This function verifies that the simulator module in the cvx package has a
-    defined version and prints it.
-
-    Raises:
-        AssertionError: If the simulator module's version is None.
-
-    """
-    assert cvx.simulator.__version__ is not None
-    print(f"Risk version: {cvx.simulator.__version__}")

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ benchmark = [
 ]
 dev = [
     { name = "cvx-linalg" },
-    { name = "cvxsimulator" },
+    { name = "jquantstats" },
     { name = "marimo" },
     { name = "pandas" },
     { name = "plotly" },
@@ -218,27 +218,11 @@ benchmark = [
 ]
 dev = [
     { name = "cvx-linalg", specifier = ">=0.3.0" },
-    { name = "cvxsimulator", specifier = ">=1.4.5" },
+    { name = "jquantstats", specifier = ">=0.6.5" },
     { name = "marimo", specifier = ">=0.23.6" },
     { name = "pandas", specifier = ">3.0" },
     { name = "plotly", specifier = ">=6.5" },
     { name = "polars", specifier = ">=1.34.0" },
-]
-
-[[package]]
-name = "cvxsimulator"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jquantstats" },
-    { name = "numpy" },
-    { name = "pandas" },
-    { name = "polars" },
-    { name = "pyarrow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/34/ceb60bcaab7eb5608b8cef01b94e38cfaacc36708ecb8384a0ed354a0f64/cvxsimulator-1.5.1.tar.gz", hash = "sha256:484f91c11eacaa8763f06c379fb016710eed97bf28e9ecf8f7f04085f730f340", size = 7664892, upload-time = "2026-04-16T08:26:00.181Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/d8/c5e9fed4f951e1ce9c3b584601b785be045537bc868f20f05bed818831d8/cvxsimulator-1.5.1-py3-none-any.whl", hash = "sha256:7fd62ebb88a4dda6c8e1d417bb8150771934aeee5dbc0460bf50574c1cd81354", size = 19983, upload-time = "2026-04-16T08:25:58.297Z" },
 ]
 
 [[package]]
@@ -828,56 +812,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
-]
-
-[[package]]
-name = "pyarrow"
-version = "23.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/41/8e6b6ef7e225d4ceead8459427a52afdc23379768f54dd3566014d7618c1/pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb", size = 34302230, upload-time = "2026-02-16T10:09:03.859Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/4a/1472c00392f521fea03ae93408bf445cc7bfa1ab81683faf9bc188e36629/pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350", size = 35850050, upload-time = "2026-02-16T10:09:11.877Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b2/bd1f2f05ded56af7f54d702c8364c9c43cd6abb91b0e9933f3d77b4f4132/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd", size = 44491918, upload-time = "2026-02-16T10:09:18.144Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9", size = 47562811, upload-time = "2026-02-16T10:09:25.792Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/94/1170e235add1f5f45a954e26cd0e906e7e74e23392dcb560de471f7366ec/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c30143b17161310f151f4a2bcfe41b5ff744238c1039338779424e38579d701", size = 48183766, upload-time = "2026-02-16T10:09:34.645Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/2d/39a42af4570377b99774cdb47f63ee6c7da7616bd55b3d5001aa18edfe4f/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db2190fa79c80a23fdd29fef4b8992893f024ae7c17d2f5f4db7171fa30c2c78", size = 50607669, upload-time = "2026-02-16T10:09:44.153Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ca/db94101c187f3df742133ac837e93b1f269ebdac49427f8310ee40b6a58f/pyarrow-23.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919", size = 27527698, upload-time = "2026-02-16T10:09:50.263Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/4b/4166bb5abbfe6f750fc60ad337c43ecf61340fa52ab386da6e8dbf9e63c4/pyarrow-23.0.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f", size = 34214575, upload-time = "2026-02-16T10:09:56.225Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/da/3f941e3734ac8088ea588b53e860baeddac8323ea40ce22e3d0baa865cc9/pyarrow-23.0.1-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:7707d2b6673f7de054e2e83d59f9e805939038eebe1763fe811ee8fa5c0cd1a7", size = 35832540, upload-time = "2026-02-16T10:10:03.428Z" },
-    { url = "https://files.pythonhosted.org/packages/88/7c/3d841c366620e906d54430817531b877ba646310296df42ef697308c2705/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86ff03fb9f1a320266e0de855dee4b17da6794c595d207f89bba40d16b5c78b9", size = 44470940, upload-time = "2026-02-16T10:10:10.704Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/a5/da83046273d990f256cb79796a190bbf7ec999269705ddc609403f8c6b06/pyarrow-23.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:813d99f31275919c383aab17f0f455a04f5a429c261cc411b1e9a8f5e4aaaa05", size = 47586063, upload-time = "2026-02-16T10:10:17.95Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/3c/b7d2ebcff47a514f47f9da1e74b7949138c58cfeb108cdd4ee62f43f0cf3/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bf5842f960cddd2ef757d486041d57c96483efc295a8c4a0e20e704cbbf39c67", size = 48173045, upload-time = "2026-02-16T10:10:25.363Z" },
-    { url = "https://files.pythonhosted.org/packages/43/b2/b40961262213beaba6acfc88698eb773dfce32ecdf34d19291db94c2bd73/pyarrow-23.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564baf97c858ecc03ec01a41062e8f4698abc3e6e2acd79c01c2e97880a19730", size = 50621741, upload-time = "2026-02-16T10:10:33.477Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/70/1fdda42d65b28b078e93d75d371b2185a61da89dda4def8ba6ba41ebdeb4/pyarrow-23.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:07deae7783782ac7250989a7b2ecde9b3c343a643f82e8a4df03d93b633006f0", size = 27620678, upload-time = "2026-02-16T10:10:39.31Z" },
-    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
-    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
-    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
-    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
-    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
-    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
-    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
-    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `large.py`: replace `pd.DataFrame`/`pd.Series` with numpy arrays throughout
- `tilting.py`: replace pandas with polars `Series`/`DataFrame`
- `factormodel.py`: drop pandas, compute `pct_change` natively in polars
- `demo.py`: replace `cvxsimulator.Builder` with a manual daily-rebalance backtest loop; use `jquantstats` for Sharpe and snapshot reporting
- `pyproject.toml`: swap `cvxsimulator` for `jquantstats` in the dev group

`demo.py` retains pandas solely for the EWM covariance computation (`returns.ewm(...).cov()`), which has no polars equivalent.

## Test plan
- [x] `uv run --group dev python book/marimo/large.py` runs without error
- [x] `uv run --group dev python book/marimo/tilting.py` runs without error
- [x] `uv run --group dev python book/marimo/factormodel.py` runs without error
- [x] `uv run --group dev python book/marimo/demo.py` runs without error and prints Sharpe ratios
- [x] `make deptry` passes
- [x] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)