### PR TITLE
Replace pandas/cvxsimulator with polars/jquantstats in marimo notebooks

### DIFF
--- a/book/marimo/demo.py
+++ b/book/marimo/demo.py
@@ -1,9 +1,7 @@
 # /// script
 # dependencies = [
 #     "marimo==0.18.4",
-#     "pandas",
 #     "polars",
-#     "pyarrow",
 #     "jquantstats",
 #     "cvxrisk"
 # ]
@@ -36,23 +34,25 @@ with app.setup:
 
 @app.cell
 def _():
-    # Load some historic stock prices
+    # Load prices and compute returns entirely in polars
     prices = pl.read_csv(str(mo.notebook_location() / "public" / "stock_prices.csv"), try_parse_dates=True)
 
-    prices = prices.to_pandas().set_index("date")
+    asset_cols = [c for c in prices.columns if c != "date"]
+    returns = prices.select([pl.col("date"), pl.col(asset_cols).pct_change()]).drop_nulls()
 
-    # Compute returns and EWM covariance (requires pandas)
-    returns = prices.pct_change().dropna(axis=0, how="all")
-    cov = returns.ewm(com=60, min_periods=100).cov().dropna(axis=0, how="all")
-    start = cov.index[0][0]
-    return prices, returns, cov, start
+    # EWM covariance via jquantstats (com=60 → span=121, warmup=100)
+    data = jqs.Data.from_returns(returns, date_col="date")
+    cov = data.utils.exponential_cov(window=121, warmup=100)
+    start = next(iter(cov))
+    return asset_cols, returns, cov, start
 
 
 @app.cell
-def _(cov, returns, start):
+def _(asset_cols, cov, returns, start):
     # Minimum-risk backtest using SampleCovariance
-    cov_dates = set(cov.index.get_level_values(0))
-    returns_bt = returns.loc[start:]
+    _returns_bt = returns.filter(pl.col("date") >= start)
+    _dates = _returns_bt["date"].to_list()
+    _ret_values = _returns_bt.select(asset_cols).to_numpy()
 
     _risk_model = SampleCovariance(num=20)
     _w = Variable(20)
@@ -60,10 +60,10 @@ def _(cov, returns, start):
     _current_w = None
 
     _port_rets = []
-    for _date in returns_bt.index:
-        if _date in cov_dates:
+    for _i, _date in enumerate(_dates):
+        if _date in cov:
             _risk_model.update(
-                cov=cov.loc[_date].values,
+                cov=cov[_date],
                 lower_assets=np.zeros(20),
                 upper_assets=np.ones(20),
             )
@@ -71,15 +71,10 @@ def _(cov, returns, start):
             _current_w = _w.value.copy()
 
         if _current_w is not None:
-            _port_rets.append(float(returns_bt.loc[_date].values @ _current_w))
+            _port_rets.append(float(_ret_values[_i] @ _current_w))
 
-    _returns_pl = pl.DataFrame(
-        {
-            "Date": returns_bt.index[-len(_port_rets) :].to_list(),
-            "SampleCovariance": _port_rets,
-        }
-    )
-    data_sc = jqs.Data.from_returns(_returns_pl, date_col="Date")
+    _returns_pl = pl.DataFrame({"date": _dates[-len(_port_rets) :], "SampleCovariance": _port_rets})
+    data_sc = jqs.Data.from_returns(_returns_pl, date_col="date")
     print(data_sc.stats.sharpe())
     return (data_sc,)
 
@@ -93,7 +88,9 @@ def _(data_sc):
 def _(returns, start):
     from cvx.risk.cvar import CVar
 
-    _returns_bt = returns.loc[start:]
+    _returns_bt = returns.filter(pl.col("date") >= start)
+    _dates = _returns_bt["date"].to_list()
+    _ret_values = _returns_bt.select([c for c in _returns_bt.columns if c != "date"]).to_numpy()
 
     _risk_model = CVar(alpha=0.80, n=40, m=20)
     _w = Variable(20)
@@ -101,11 +98,11 @@ def _(returns, start):
     _current_w = None
 
     _port_rets = []
-    for _i, _date in enumerate(_returns_bt.index):
-        _hist = _returns_bt.iloc[: _i + 1].tail(40)
+    for _i in range(len(_dates)):
+        _hist = _ret_values[max(0, _i - 39) : _i + 1]
         if len(_hist) == 40:
             _risk_model.update(
-                returns=_hist.values,
+                returns=_hist,
                 lower_assets=np.zeros(20),
                 upper_assets=np.ones(20),
             )
@@ -113,15 +110,10 @@ def _(returns, start):
             _current_w = _w.value.copy()
 
         if _current_w is not None:
-            _port_rets.append(float(_returns_bt.iloc[_i].values @ _current_w))
+            _port_rets.append(float(_ret_values[_i] @ _current_w))
 
-    _returns_pl = pl.DataFrame(
-        {
-            "Date": _returns_bt.index[-len(_port_rets) :].to_list(),
-            "CVar": _port_rets,
-        }
-    )
-    data_cvar = jqs.Data.from_returns(_returns_pl, date_col="Date")
+    _returns_pl = pl.DataFrame({"date": _dates[-len(_port_rets) :], "CVar": _port_rets})
+    data_cvar = jqs.Data.from_returns(_returns_pl, date_col="date")
     print(data_cvar.stats.sharpe())
     return (data_cvar,)
 

--- a/book/marimo/factormodel.py
+++ b/book/marimo/factormodel.py
@@ -4,8 +4,7 @@
 #     "numpy",
 #     "polars",
 #     "cvxrisk",
-#     "cvx-linalg",
-#     "pyarrow"
+#     "cvx-linalg"
 # ]
 #
 # [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dev = [
     "marimo>=0.23.6",      # Interactive notebook environment
     "polars>=1.34.0",      # Fast DataFrame library (alternative to pandas)
     "plotly>=6.5",
-    "pandas>3.0",
     "cvx-linalg>=0.3.0",   # Linear algebra utilities used in marimo notebooks
 ]
 # Benchmark dependencies – install with: uv sync --group benchmark

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,8 @@ packages = ["src/cvx"]  # Only include the cvx package in the wheel
 # Map package names to their actual module names to suppress warnings
 [tool.deptry.package_module_name_map]
 numpy = "numpy"
-pandas = "pandas"
 clarabel = "clarabel"
 scipy = "scipy"
-cvxsimulator = "cvxsimulator"
 marimo = "marimo"
 plotly = "plotly"
 polars = "polars"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/cvxgrp/cvxrisk"
 [dependency-groups]
 # Development dependencies for testing, linting, and documentation
 dev = [
-    "jquantstats>=0.6.5",  # Portfolio performance analysis and reporting
+    "jquantstats>=0.8.2",  # Portfolio performance analysis and reporting
     "marimo>=0.23.6",      # Interactive notebook environment
     "polars>=1.34.0",      # Fast DataFrame library (alternative to pandas)
     "plotly>=6.5",

--- a/src/cvx/risk/portfolio/min_risk.py
+++ b/src/cvx/risk/portfolio/min_risk.py
@@ -57,13 +57,17 @@ LinearConstraint = tuple[np.ndarray, float | None, float | None]
 
 
 class _SolvableModel(Protocol):
+    """Protocol for risk models that support direct Clarabel solving."""
+
     def solve_minrisk(
         self,
         weights: Variable,
         base: np.ndarray,
         extra_constraints: list[tuple[np.ndarray, float | None, float | None]],
         y_var: Variable | None = None,
-    ) -> tuple[float | None, float | None, str]: ...
+    ) -> tuple[float | None, float | None, str]:
+        """Solve the minimum-risk problem and return (objective, risk, status)."""
+        ...
 
 
 @dataclass

--- a/tests/risk/factor/test_factor.py
+++ b/tests/risk/factor/test_factor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 import polars as pl
 import pytest
 from cvx.linalg import pca as principal_components
@@ -28,8 +27,9 @@ def returns(resource_dir) -> pl.DataFrame:
         polars.DataFrame: DataFrame containing stock returns
 
     """
-    prices = pd.read_csv(resource_dir / "stock_prices.csv", index_col=0, header=0, parse_dates=True)
-    return pl.from_pandas(prices.pct_change().fillna(0.0).reset_index(drop=True))
+    prices = pl.read_csv(resource_dir / "stock_prices.csv", try_parse_dates=True)
+    asset_cols = [c for c in prices.columns if c != prices.columns[0]]
+    return prices.select(pl.col(asset_cols).pct_change().fill_null(0.0))
 
 
 def test_timeseries_model(returns: pl.DataFrame) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,6 @@ dev = [
     { name = "cvx-linalg" },
     { name = "jquantstats" },
     { name = "marimo" },
-    { name = "pandas" },
     { name = "plotly" },
     { name = "polars" },
 ]
@@ -220,7 +219,6 @@ dev = [
     { name = "cvx-linalg", specifier = ">=0.3.0" },
     { name = "jquantstats", specifier = ">=0.8.2" },
     { name = "marimo", specifier = ">=0.23.6" },
-    { name = "pandas", specifier = ">3.0" },
     { name = "plotly", specifier = ">=6.5" },
     { name = "polars", specifier = ">=1.34.0" },
 ]
@@ -659,66 +657,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pandas"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/16/b5c76b838fd9bf6ce84d3a53346b8874ec05c5f0040d75ef2c320100cd2a/pandas-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:455f6f8139d4282188f526868dbc3c828470e88a3d9d59a891bd46a455f21b98", size = 10338495, upload-time = "2026-05-11T18:52:11.558Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/b0/a4ffc4ae74d2d822200dcc46898987d8eb6032d1e2b219cae39da6f5cbcc/pandas-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4e15135e2ee5df1063313e2425ceef8ac0f4ae775893815b0923651b806a5639", size = 9938250, upload-time = "2026-05-11T18:52:17.005Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/b2/3323601a52caee42c019e370090ca4544b241437240ca04f786cce82b0cf/pandas-3.0.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:05f1f1752b8533ea03f7f39a9c15b1a058d067bb48f4748948e7a8691e0510f2", size = 10770558, upload-time = "2026-05-11T18:52:19.865Z" },
-    { url = "https://files.pythonhosted.org/packages/32/f1/bbecd2f867b97abebe0f9b53d750f862251b40337e061b36676ded3d920f/pandas-3.0.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a1e45c80cceb3b4a21bc5939d52e8cbd8d9b7305309219d59e9754d9ce09e27", size = 11274611, upload-time = "2026-05-11T18:52:22.622Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/4f/eafabf2d5fae5adf143b4d18d3706c5efdc368a7c4eb1ee8a3eddabbd0f6/pandas-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:14da8316da4d0c5a77618425996bfb1248ca87fc2c1486e6fde4652bd18b5824", size = 11784670, upload-time = "2026-05-11T18:52:25.4Z" },
-    { url = "https://files.pythonhosted.org/packages/49/44/1eb20389301b57b19cc099a1c2f662501f72f08a65f912d05822613c1532/pandas-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a55066a0505dae0ba2b50a46637db34b46f9094c65c5d4800794ef6335010938", size = 12353708, upload-time = "2026-05-11T18:52:28.139Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/62/c321f13b5ba1819fc8dca456c7fce578da2dcfecff1abbf0eaddf8406c0f/pandas-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:6674ab18ad8c57802867264b00e15e7bb904700cdd9046e3b2fa1fce237439ea", size = 9907609, upload-time = "2026-05-11T18:52:30.982Z" },
-    { url = "https://files.pythonhosted.org/packages/53/85/1b7f563ebc6357c27233a02a96b589bcce1fa9c6eb89fb4f0e56421d277e/pandas-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:5cc09a68b3120e0f54870dede8287a7bb1fa463907e4fcec1ea77cab6179bf7a", size = 9165596, upload-time = "2026-05-11T18:52:33.334Z" },
-    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
-    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
-    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
-    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
-    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
-    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
-    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
-    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
-    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
-    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
-    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
-    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
-    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
-    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
-    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
-]
-
-[[package]]
 name = "parso"
 version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
@@ -872,18 +810,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
-]
-
-[[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -1071,15 +997,6 @@ wheels = [
 ]
 
 [[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
 name = "starlette"
 version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1108,15 +1025,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "tzdata"
-version = "2025.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -218,7 +218,7 @@ benchmark = [
 ]
 dev = [
     { name = "cvx-linalg", specifier = ">=0.3.0" },
-    { name = "jquantstats", specifier = ">=0.6.5" },
+    { name = "jquantstats", specifier = ">=0.8.2" },
     { name = "marimo", specifier = ">=0.23.6" },
     { name = "pandas", specifier = ">3.0" },
     { name = "plotly", specifier = ">=6.5" },
@@ -296,7 +296,7 @@ wheels = [
 
 [[package]]
 name = "jquantstats"
-version = "0.6.5"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jinja2" },
@@ -306,9 +306,9 @@ dependencies = [
     { name = "polars" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/55/6c8874fe3cf697bb2a29d93490447f788b8d86d4d96e88ce4309d8091ab1/jquantstats-0.6.5.tar.gz", hash = "sha256:10dfbc2b2259414e40abcce0a03a9730ac92bdf7c0afe212998758e1339d3e22", size = 92104, upload-time = "2026-04-14T13:38:22.596Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/62/f0acbaa44d288a32fd522f392ce25d87f71bc0c9de7e8f85de9fafb34122/jquantstats-0.8.2.tar.gz", hash = "sha256:0fa75ec19fa679abe1912086416143ca23a6dc76212390457da5ffc2b5bc55d5", size = 93005, upload-time = "2026-05-14T07:46:25.592Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/fc/e41877f951704d210b9f0181ccfc026ca7984fbc2bf3914a7dd8083af745/jquantstats-0.6.5-py3-none-any.whl", hash = "sha256:ade8e8f48cd06c18878bf0b430dafc9c4dcba4ba4b625bc9c62d9b6d9d96ec88", size = 104390, upload-time = "2026-04-14T13:38:21.23Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/41/68d500440b9ca44a628896743e0e28bdf25bb0c4db9a6ecc5dffba5b37b6/jquantstats-0.8.2-py3-none-any.whl", hash = "sha256:11bb555e1c63af90b8fa46e3baa24bc16b297519016d4b7fddddfa4065d8c531", size = 107105, upload-time = "2026-05-14T07:46:23.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `large.py`: replace `pd.DataFrame`/`pd.Series` with numpy arrays
- `tilting.py`: replace pandas with polars `Series`/`DataFrame`
- `factormodel.py`: drop pandas, compute `pct_change` natively in polars
- `demo.py`: replace `cvxsimulator.Builder` with a manual daily-rebalance backtest loop and `jquantstats` for performance reporting; replace pandas EWM covariance with `jqs.Data.utils.exponential_cov` (pure polars/numpy)
- `pyproject.toml`: swap `cvxsimulator`, `pandas`, `pyarrow` for `jquantstats>=0.8.2` in the dev group

No pandas or pyarrow dependency remains anywhere in the notebooks or dev group.

## Test plan
- [ ] `uv run --group dev python book/marimo/large.py` runs without error
- [ ] `uv run --group dev python book/marimo/tilting.py` runs without error
- [ ] `uv run --group dev python book/marimo/factormodel.py` runs without error
- [ ] `uv run --group dev python book/marimo/demo.py` runs without error and prints Sharpe ratios
- [ ] `make deptry` passes
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)