### PR TITLE
Fix factor tracking error, dedupe solver code, harden test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ local.mk
 
 .bandit-baseline.json
 
+
+# Mutation testing cache (mutmut)
+.mutmut-cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing to cvxrisk
+
+We welcome all contributions — you don't need to be an expert to help out.
+
+The full contributing guide, including development setup, coding style,
+testing instructions, and the pull-request checklist, lives in
+[.rhiza/CONTRIBUTING.md](.rhiza/CONTRIBUTING.md).
+
+Quick start:
+
+```bash
+make install   # set up the development environment (uv-based)
+make test      # run the test suite
+make fmt       # format and lint
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [cvxrisk](https://www.cvxgrp.org/cvxrisk/): Convex Optimization for Portfolio Risk Management
 
 [![PyPI version](https://badge.fury.io/py/cvxrisk.svg)](https://badge.fury.io/py/cvxrisk)
-[![Apache 2.0 License](https://img.shields.io/badge/License-APACHEv2-brightgreen.svg)](https://github.com/cvxgrp/cvxrisk/blob/master/LICENSE)
+[![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/cvxgrp/cvxrisk/blob/main/LICENSE)
 [![Downloads](https://static.pepy.tech/personalized-badge/cvxrisk?period=month&units=international_system&left_color=black&right_color=orange&left_text=PyPI%20downloads%20per%20month)](https://pepy.tech/project/cvxrisk)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://github.com/renovatebot/renovate)
 [![Coverage](https://www.cvxgrp.org/cvxrisk/coverage-badge.svg)](https://www.cvxgrp.org/cvxrisk/reports/html-coverage/)
@@ -19,11 +19,10 @@ them in your optimization problems.
 
 ## 🚀 Installation
 
-```bash
-# Install from PyPI
-pip install cvxrisk
+Install from source (PyPI releases are currently paused; the package on
+PyPI predates the direct-Clarabel rewrite and has a different API):
 
-# For development installation
+```bash
 git clone https://github.com/cvxgrp/cvxrisk.git
 cd cvxrisk
 make install
@@ -209,7 +208,7 @@ make marimo
 
 ## 📄 License
 
-cvxrisk is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.
+cvxrisk is licensed under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## 👥 Contributing
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,62 @@
+# Mathematical formulations
+
+cvxrisk solves minimum-risk portfolio problems directly with the
+[Clarabel](https://github.com/oxfordcontrol/Clarabel.rs) conic solver.
+This page documents the exact conic program each risk model builds in its
+`solve_minrisk` method, so the implementations can be audited against the
+mathematics.
+
+All problems share the budget constraint and weight bounds
+
+$$\sum_i w_i = 1, \qquad \ell_w \le w \le u_w,$$
+
+plus any user-supplied linear constraints $\ell \le a^T w \le u$
+(equalities when $\ell = u$). A base portfolio $b$ (default $0$) turns the
+problem into tracking-error minimization over the active position $w - b$.
+
+## Sample covariance
+
+With $R$ the upper-triangular Cholesky factor of the covariance matrix
+($R^T R = \Sigma$), the problem is the second-order cone program
+
+$$\min_{t,\,w}\ t \quad \text{s.t.} \quad \lVert R (w - b) \rVert_2 \le t$$
+
+over the variables $x = [t, w]$. The optimal $t$ is the portfolio
+volatility $\sqrt{(w-b)^T \Sigma (w-b)}$.
+
+## Factor model
+
+With factor exposure $\beta \in \mathbb{R}^{k \times n}$, factor covariance
+Cholesky factor $R_f$ ($R_f^T R_f = \Sigma_f$), and idiosyncratic
+volatilities $\sigma$, the problem introduces the factor position
+$y = \beta w$ as an explicit variable:
+
+$$\min_{t,\,w,\,y}\ t \quad \text{s.t.} \quad
+\left\lVert \begin{bmatrix} R_f\,(y - \beta b) \\ \operatorname{diag}(\sigma)\,(w - b) \end{bmatrix} \right\rVert_2 \le t,
+\qquad y = \beta w, \qquad \ell_y \le y \le u_y$$
+
+over $x = [t, w, y]$. The optimal $t$ equals the total tracking error
+$\sqrt{(w-b)^T (\beta^T \Sigma_f \beta + \operatorname{diag}(\sigma^2)) (w-b)}$,
+combining systematic and idiosyncratic risk of the active position.
+
+## Conditional Value at Risk
+
+Given scenario returns $R \in \mathbb{R}^{T \times n}$ and confidence level
+$\alpha$, the model minimizes the expected loss in the worst
+$k = \lfloor T (1-\alpha) \rfloor$ scenarios using the
+Rockafellar–Uryasev linear program over $x = [w, \gamma, u]$:
+
+$$\min_{w,\,\gamma,\,u}\ \gamma + \frac{1}{k} \sum_{t=1}^{T} u_t
+\quad \text{s.t.} \quad u \ge -R\,(w - b) - \gamma, \qquad u \ge 0,$$
+
+where $\gamma$ plays the role of the Value at Risk and $u$ the scenario
+losses beyond it.
+
+## Implementation
+
+The shared assembly of these programs — stacking constraint blocks, mapping
+user constraints to cones, and invoking Clarabel — lives in
+`cvx.core.ConeProgramBuilder`. Each model contributes only its
+model-specific blocks (the SOC above for the covariance models, the
+scenario constraints for CVaR); identity-like blocks are built directly in
+sparse form so large universes and scenario sets stay memory-efficient.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Mathematics: models.md
   - Notebooks:
     - Demo: notebooks/demo.html
     - Factor Model: notebooks/factormodel.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,12 @@ dev = [
 ]
 # Test dependencies
 test = [
+    "hypothesis>=6.100",    # Property-based testing
+    "mutmut>=2.5,<3",       # Mutation testing (2.x matches the CLI flags used by `make mutation`)
     "pytest>=9.0",
     "pytest-cov>=7.0",
     "pytest-mock>=3.0",
+    "pytest-timeout>=2.3",  # Enforces the per-test timeout configured in pytest.ini
 ]
 # Lint dependencies
 lint = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,13 +1,15 @@
 [pytest]
-testpaths = tests
+# Collect unit tests and the docstring examples in src
+testpaths = tests src
 # Enable live logs on console
 log_cli = true
 # Show DEBUG+ messages
 log_cli_level = DEBUG
 log_cli_format = %(asctime)s %(levelname)s %(name)s: %(message)s
 log_cli_date_format = %H:%M:%S
-# Show extra summary info for skipped/failed tests
-addopts = -ra
+# Show extra summary info for skipped/failed tests; run doctests in src modules.
+# importlib mode avoids module-name clashes between conftest files during doctest collection.
+addopts = -ra --doctest-modules --import-mode=importlib
 timeout = 60
 # Register custom markers
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+# mutmut (mutation testing) configuration — used by `make mutation`.
+# mutmut 2.x reads its configuration from setup.cfg only; nothing else in
+# this project uses this file (the build is configured in pyproject.toml).
+[mutmut]
+paths_to_mutate=src/cvx
+tests_dir=tests
+# Skip the Hypothesis property tests during mutation runs: they multiply the
+# per-mutant runtime without adding kill power beyond the reference-solver
+# and unit tests, which cover the same invariants deterministically.
+runner=python -m pytest -x -q -m "not property" --ignore=tests/benchmarks -p no:cacheprovider

--- a/src/cvx/core/__init__.py
+++ b/src/cvx/core/__init__.py
@@ -1,11 +1,13 @@
 """Core building blocks shared across cvx packages.
 
 Exposes the fundamental types used to build parametric optimization models:
-:class:`Model`, :class:`Bounds`, :class:`Parameter`, and :class:`Variable`.
+:class:`Model`, :class:`Bounds`, :class:`Parameter`, and :class:`Variable`,
+plus the :class:`ConeProgramBuilder` helper for assembling Clarabel problems.
 
 """
 
 from .bounds import Bounds as Bounds
+from .conic import ConeProgramBuilder as ConeProgramBuilder
 from .model import Model as Model
 from .parameter import Parameter as Parameter
 from .variable import Variable as Variable

--- a/src/cvx/core/bounds.py
+++ b/src/cvx/core/bounds.py
@@ -1,16 +1,7 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 """Box constraints for optimization variables.
 
 This module provides the :class:`Bounds` class, which tracks lower and upper
@@ -160,6 +151,10 @@ class Bounds(Model):
             **kwargs: Must contain ``lower_{name}`` and ``upper_{name}`` keys
                 with numpy arrays of length ≤ ``m``.
 
+        Raises:
+            ValueError: If a required key is missing or an array is longer
+                than ``m``.
+
         Example:
             >>> import numpy as np
             >>> from cvx.core.bounds import Bounds
@@ -172,15 +167,17 @@ class Bounds(Model):
             array([0. , 0.1, 0.2])
 
         """
-        lower = kwargs[self._f("lower")]
-        lower_arr = np.zeros(self.m)
-        lower_arr[: len(lower)] = lower
-        self.parameter[self._f("lower")].value = lower_arr
-
-        upper = kwargs[self._f("upper")]
-        upper_arr = np.zeros(self.m)
-        upper_arr[: len(upper)] = upper
-        self.parameter[self._f("upper")].value = upper_arr
+        for key in (self._f("lower"), self._f("upper")):
+            if key not in kwargs:
+                msg = f"update() requires a '{key}' argument"
+                raise ValueError(msg)
+            values = kwargs[key]
+            if len(values) > self.m:
+                msg = f"'{key}' has length {len(values)} but the maximum is {self.m}"
+                raise ValueError(msg)
+            arr = np.zeros(self.m)
+            arr[: len(values)] = values
+            self.parameter[key].value = arr
 
     def get_bounds(self) -> tuple[np.ndarray, np.ndarray]:
         """Return ``(lower, upper)`` bound arrays of length ``m``.

--- a/src/cvx/core/conic.py
+++ b/src/cvx/core/conic.py
@@ -1,0 +1,173 @@
+#    Copyright (c) 2025 Jebel Quant Research
+#
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
+"""Shared helper for building and solving Clarabel conic programs.
+
+This module provides the :class:`ConeProgramBuilder`, a small utility that
+accumulates the constraint blocks and cones of a conic program
+
+    minimize    q' x
+    subject to  A x + s = b,  s in K
+
+and solves it with Clarabel. The risk models use it to express their
+minimum-risk problems without repeating the boilerplate of stacking
+constraint blocks, handling user-supplied linear constraints, and
+invoking the solver.
+
+Example:
+    Minimize x subject to x >= 1:
+
+    >>> import clarabel
+    >>> import numpy as np
+    >>> from cvx.core import ConeProgramBuilder
+    >>> builder = ConeProgramBuilder(n_vars=1)
+    >>> builder.add(np.array([[-1.0]]), np.array([-1.0]), clarabel.NonnegativeConeT(1))
+    >>> solution, status = builder.solve(q=np.array([1.0]))
+    >>> status
+    'Solved'
+    >>> bool(np.isclose(solution.x[0], 1.0))
+    True
+
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import clarabel
+import numpy as np
+from scipy import sparse
+
+# User-supplied linear constraint: (a, lb, ub) meaning lb <= a @ w <= ub.
+# Use None for one-sided bounds; lb == ub yields an equality constraint.
+LinearConstraint = tuple[np.ndarray, float | None, float | None]
+
+
+class ConeProgramBuilder:
+    """Accumulate constraint blocks for a Clarabel conic program and solve it.
+
+    Constraints are added as blocks of the stacked system ``A x + s = b`` with
+    slack ``s`` in the corresponding cone. The builder assembles the blocks
+    into sparse matrices and runs the Clarabel solver.
+
+    Attributes:
+        n_vars: Total number of decision variables in the program.
+
+    """
+
+    def __init__(self, n_vars: int) -> None:
+        """Create an empty builder for a program with ``n_vars`` variables.
+
+        Args:
+            n_vars: Total number of decision variables.
+
+        """
+        self.n_vars = n_vars
+        self._a_blocks: list[sparse.csr_matrix] = []
+        self._b_blocks: list[np.ndarray] = []
+        self._cones: list[Any] = []
+
+    def block(self, rows: int) -> np.ndarray:
+        """Return a zero matrix with ``rows`` rows and one column per variable.
+
+        Args:
+            rows: Number of constraint rows in the block.
+
+        Returns:
+            A zero matrix of shape ``(rows, n_vars)`` ready to be filled in.
+
+        """
+        return np.zeros((rows, self.n_vars))
+
+    def add(self, a_block: np.ndarray | sparse.spmatrix, b_block: np.ndarray, cone: Any) -> None:
+        """Append the constraint block ``a_block @ x + s = b_block`` with ``s`` in ``cone``.
+
+        Args:
+            a_block: Constraint matrix block of shape ``(rows, n_vars)``,
+                either dense or scipy sparse. Blocks are stored in sparse
+                form so large structured constraints stay memory-efficient.
+            b_block: Right-hand side vector of length ``rows``.
+            cone: Clarabel cone for the slack of this block.
+
+        """
+        self._a_blocks.append(sparse.csr_matrix(a_block))
+        self._b_blocks.append(b_block)
+        self._cones.append(cone)
+
+    def add_sum_constraint(self, cols: slice, total: float = 1.0) -> None:
+        """Constrain the variables selected by ``cols`` to sum to ``total``.
+
+        Args:
+            cols: Column slice selecting the variables.
+            total: Required sum of the selected variables.
+
+        """
+        a = self.block(1)
+        a[0, cols] = 1.0
+        self.add(a, np.array([total]), clarabel.ZeroConeT(1))
+
+    def add_variable_bounds(self, cols: slice, lower: np.ndarray, upper: np.ndarray) -> None:
+        """Add elementwise bounds ``lower <= x[cols] <= upper``.
+
+        The identity blocks are built directly in sparse form, so the cost is
+        O(m) rather than O(m * n_vars).
+
+        Args:
+            cols: Column slice selecting the variables to bound.
+            lower: Lower bound for each selected variable.
+            upper: Upper bound for each selected variable.
+
+        """
+        m = len(lower)
+        eye = sparse.identity(m, format="csr")
+        left = sparse.csr_matrix((m, cols.start))
+        right = sparse.csr_matrix((m, self.n_vars - cols.stop))
+        self.add(sparse.hstack([left, -eye, right]), -lower, clarabel.NonnegativeConeT(m))
+        self.add(sparse.hstack([left, eye, right]), upper, clarabel.NonnegativeConeT(m))
+
+    def add_linear_constraints(self, constraints: list[LinearConstraint], cols: slice) -> None:
+        """Add user-supplied linear constraints ``lb <= a @ x[cols] <= ub``.
+
+        Args:
+            constraints: List of ``(a, lb, ub)`` tuples. Use ``None`` to drop
+                one side; ``lb == ub`` produces an equality constraint.
+            cols: Column slice the coefficient vectors refer to (typically the
+                portfolio weights).
+
+        """
+        for coeffs, lower, upper in constraints:
+            a = np.asarray(coeffs)
+            if lower is not None and upper is not None and lower == upper:
+                row = self.block(1)
+                row[0, cols] = a
+                self.add(row, np.array([lower]), clarabel.ZeroConeT(1))
+                continue
+            if lower is not None:
+                row = self.block(1)
+                row[0, cols] = -a
+                self.add(row, np.array([-lower]), clarabel.NonnegativeConeT(1))
+            if upper is not None:
+                row = self.block(1)
+                row[0, cols] = a
+                self.add(row, np.array([upper]), clarabel.NonnegativeConeT(1))
+
+    def solve(self, q: np.ndarray) -> tuple[Any, str]:
+        """Assemble the accumulated blocks, solve with Clarabel, and return the result.
+
+        Args:
+            q: Linear objective vector of length ``n_vars``.
+
+        Returns:
+            Tuple ``(solution, status)`` where ``solution`` is the Clarabel
+            solution object and ``status`` its status as a string.
+
+        """
+        p = sparse.csc_matrix((self.n_vars, self.n_vars))
+        a = sparse.vstack(self._a_blocks, format="csc")
+        b = np.concatenate(self._b_blocks)
+
+        settings = clarabel.DefaultSettings()
+        settings.verbose = False
+        solution = clarabel.DefaultSolver(p, q, a, b, self._cones, settings).solve()
+        return solution, str(solution.status)

--- a/src/cvx/core/model.py
+++ b/src/cvx/core/model.py
@@ -1,16 +1,7 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 """Abstract parametric model with named numpy-array parameters.
 
 This module provides the :class:`Model` abstract base class for any

--- a/src/cvx/core/parameter.py
+++ b/src/cvx/core/parameter.py
@@ -1,16 +1,7 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 """Parameter class for risk models.
 
 This module provides a simple parameter class that stores a named numpy array

--- a/src/cvx/core/variable.py
+++ b/src/cvx/core/variable.py
@@ -1,16 +1,7 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 """Decision variable class for portfolio optimization.
 
 This module provides the Variable class, which acts as a placeholder for

--- a/src/cvx/risk/__init__.py
+++ b/src/cvx/risk/__init__.py
@@ -34,19 +34,10 @@ Modules:
 
 """
 
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 import importlib.metadata
 
 __version__ = importlib.metadata.version("cvxrisk")

--- a/src/cvx/risk/cvar/__init__.py
+++ b/src/cvx/risk/cvar/__init__.py
@@ -24,17 +24,8 @@ Example:
 
 """
 
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 from .cvar import CVar as CVar

--- a/src/cvx/risk/cvar/cvar.py
+++ b/src/cvx/risk/cvar/cvar.py
@@ -30,19 +30,10 @@ Example:
 
 """
 
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -52,7 +43,7 @@ import clarabel
 import numpy as np
 from scipy import sparse
 
-from cvx.core import Bounds, Model, Parameter, Variable
+from cvx.core import Bounds, ConeProgramBuilder, Model, Parameter, Variable
 
 
 @dataclass
@@ -211,6 +202,10 @@ class CVar(Model):
                 - lower_assets: Array of lower bounds for asset weights.
                 - upper_assets: Array of upper bounds for asset weights.
 
+        Raises:
+            ValueError: If ``returns`` is missing, has the wrong number of
+                scenarios, or more columns than the model capacity ``m``.
+
         Example:
             >>> import numpy as np
             >>> from cvx.risk.cvar import CVar
@@ -227,7 +222,19 @@ class CVar(Model):
             (50, 3)
 
         """
-        ret = kwargs["returns"]
+        if "returns" not in kwargs:
+            msg = "update() requires a 'returns' argument"
+            raise ValueError(msg)
+        ret = np.asarray(kwargs["returns"])
+        if ret.ndim != 2:
+            msg = f"returns must be a 2d matrix of shape (n, num_assets), got shape {ret.shape}"
+            raise ValueError(msg)
+        if ret.shape[0] != self.n:
+            msg = f"returns has {ret.shape[0]} scenarios but the model expects n={self.n}"
+            raise ValueError(msg)
+        if ret.shape[1] > self.m:
+            msg = f"Too many assets: returns has {ret.shape[1]} columns but the model capacity is m={self.m}"
+            raise ValueError(msg)
         num_assets = ret.shape[1]
 
         returns_arr = np.zeros((self.n, self.m))
@@ -242,88 +249,57 @@ class CVar(Model):
         extra_constraints: list[tuple[np.ndarray, float | None, float | None]],
         y_var: Variable | None = None,
     ) -> tuple[float | None, float | None, str]:
-        """Build and solve the Clarabel LP for this model."""
+        """Build and solve the Clarabel LP for this model.
+
+        Raises:
+            ValueError: If the weights dimension exceeds the model capacity ``m``.
+
+        """
         n = weights.n
+        if n > self.m:
+            msg = f"weights has dimension {n} but the model capacity is m={self.m}"
+            raise ValueError(msg)
         T = self.n  # noqa: N806
         k = self.k
         R = self.parameter["R"].value  # noqa: N806
         lb_w, ub_w = self.bounds.get_bounds()
 
         R_n = R[:, :n]  # noqa: N806
-        n_vars = n + 1 + T
-        P = sparse.csc_matrix((n_vars, n_vars))  # noqa: N806
-        q = np.zeros(n_vars)
-        q[n] = 1.0
-        q[n + 1 :] = 1.0 / k
 
-        A_rows: list[np.ndarray] = []  # noqa: N806
-        b_rows: list[np.ndarray] = []
-        cones: list[Any] = []
+        # Variables: x = [w, gamma, u] (Rockafellar-Uryasev formulation)
+        # with gamma the VaR level and u the scenario excess losses.
+        w_cols = slice(0, n)
+        gamma_col = n
+        u_cols = slice(n + 1, n + 1 + T)
+        builder = ConeProgramBuilder(n_vars=n + 1 + T)
 
-        A_cvar = np.zeros((T, n_vars))  # noqa: N806
-        A_cvar[:, :n] = -R_n
-        A_cvar[:, n] = -1.0
-        A_cvar[:, n + 1 :] = -np.eye(T)
-        A_rows.append(A_cvar)
-        b_rows.append(R_n @ base)
-        cones.append(clarabel.NonnegativeConeT(T))
+        # u >= -R @ (w - base) - gamma  (scenario losses beyond VaR)
+        # Built directly in sparse form: dense (T x n_vars) blocks would be
+        # O(T^2) memory for what is mostly an identity over the u variables.
+        a_cvar = sparse.hstack(
+            [sparse.csr_matrix(-R_n), sparse.csr_matrix(-np.ones((T, 1))), -sparse.identity(T, format="csr")],
+            format="csr",
+        )
+        builder.add(a_cvar, R_n @ base, clarabel.NonnegativeConeT(T))
 
-        A_u = np.zeros((T, n_vars))  # noqa: N806
-        A_u[:, n + 1 :] = -np.eye(T)
-        A_rows.append(A_u)
-        b_rows.append(np.zeros(T))
-        cones.append(clarabel.NonnegativeConeT(T))
+        # u >= 0
+        a_u = sparse.hstack(
+            [sparse.csr_matrix((T, n + 1)), -sparse.identity(T, format="csr")],
+            format="csr",
+        )
+        builder.add(a_u, np.zeros(T), clarabel.NonnegativeConeT(T))
 
-        A_eq = np.zeros((1, n_vars))  # noqa: N806
-        A_eq[0, :n] = 1.0
-        A_rows.append(A_eq)
-        b_rows.append(np.array([1.0]))
-        cones.append(clarabel.ZeroConeT(1))
+        builder.add_sum_constraint(w_cols)
+        builder.add_variable_bounds(w_cols, lb_w[:n], ub_w[:n])
+        builder.add_linear_constraints(extra_constraints, w_cols)
 
-        A_lb = np.zeros((n, n_vars))  # noqa: N806
-        A_lb[:, :n] = -np.eye(n)
-        A_rows.append(A_lb)
-        b_rows.append(-lb_w[:n])
-        cones.append(clarabel.NonnegativeConeT(n))
-
-        A_ub = np.zeros((n, n_vars))  # noqa: N806
-        A_ub[:, :n] = np.eye(n)
-        A_rows.append(A_ub)
-        b_rows.append(ub_w[:n])
-        cones.append(clarabel.NonnegativeConeT(n))
-
-        for a, lb_val, ub_val in extra_constraints:
-            a = np.asarray(a)
-            if lb_val is not None and ub_val is not None and lb_val == ub_val:
-                A_extra = np.zeros((1, n_vars))  # noqa: N806
-                A_extra[0, :n] = a
-                A_rows.append(A_extra)
-                b_rows.append(np.array([lb_val]))
-                cones.append(clarabel.ZeroConeT(1))
-            else:
-                if lb_val is not None:
-                    A_extra = np.zeros((1, n_vars))  # noqa: N806
-                    A_extra[0, :n] = -a
-                    A_rows.append(A_extra)
-                    b_rows.append(np.array([-lb_val]))
-                    cones.append(clarabel.NonnegativeConeT(1))
-                if ub_val is not None:
-                    A_extra = np.zeros((1, n_vars))  # noqa: N806
-                    A_extra[0, :n] = a
-                    A_rows.append(A_extra)
-                    b_rows.append(np.array([ub_val]))
-                    cones.append(clarabel.NonnegativeConeT(1))
-
-        A = sparse.csc_matrix(np.vstack(A_rows))  # noqa: N806
-        b = np.concatenate(b_rows)
-
-        settings = clarabel.DefaultSettings()
-        settings.verbose = False
-        sol = clarabel.DefaultSolver(P, q, A, b, cones, settings).solve()
-        status = str(sol.status)
+        q = np.zeros(builder.n_vars)
+        q[gamma_col] = 1.0
+        q[u_cols] = 1.0 / k
+        sol, status = builder.solve(q)
 
         if "Solved" in status:
-            weights.value = np.array(sol.x[:n])
+            weights.value = np.array(sol.x[w_cols])
             cvar_val = float(q @ sol.x)
             return cvar_val, cvar_val, status
         return None, None, status

--- a/src/cvx/risk/factor/__init__.py
+++ b/src/cvx/risk/factor/__init__.py
@@ -26,17 +26,8 @@ Example:
 
 """
 
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 from .factor import FactorModel as FactorModel

--- a/src/cvx/risk/factor/factor.py
+++ b/src/cvx/risk/factor/factor.py
@@ -1,16 +1,7 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 """Factor risk model.
 
 This module provides the FactorModel class, which implements a factor-based
@@ -57,7 +48,7 @@ import numpy as np
 from cvx.linalg import cholesky, norm
 from scipy import sparse
 
-from cvx.core import Bounds, Model, Parameter, Variable
+from cvx.core import Bounds, ConeProgramBuilder, Model, Parameter, Variable
 
 
 @dataclass
@@ -259,7 +250,10 @@ class FactorModel(Model):
                 - upper_factors: Array of upper bounds for factor exposures.
 
         Raises:
-            ValueError: If number of factors or assets exceeds maximum.
+            ValueError: If a required argument is missing, the number of
+                factors or assets exceeds the maximum, or the shapes of
+                ``cov`` and ``idiosyncratic_risk`` are inconsistent with
+                ``exposure``.
 
         Example:
             >>> import numpy as np
@@ -277,12 +271,14 @@ class FactorModel(Model):
             ... )
 
         """
-        self.parameter["exposure"].value = np.zeros((self.k, self.assets))
-        self.parameter["chol"].value = np.zeros((self.k, self.k))
-        self.parameter["idiosyncratic_risk"].value = np.zeros(self.assets)
+        missing = [key for key in ("exposure", "cov", "idiosyncratic_risk") if key not in kwargs]
+        if missing:
+            msg = f"update() missing required arguments: {', '.join(missing)}"
+            raise ValueError(msg)
 
-        # get the exposure
-        exposure = kwargs["exposure"]
+        exposure = np.asarray(kwargs["exposure"])
+        cov = np.asarray(kwargs["cov"])
+        idiosyncratic_risk = np.asarray(kwargs["idiosyncratic_risk"])
 
         # extract dimensions
         k, assets = exposure.shape
@@ -292,10 +288,20 @@ class FactorModel(Model):
         if assets > self.assets:
             msg = "Too many assets"
             raise ValueError(msg)
+        if cov.shape != (k, k):
+            msg = f"cov must have shape ({k}, {k}) to match exposure, got {cov.shape}"
+            raise ValueError(msg)
+        if idiosyncratic_risk.shape != (assets,):
+            msg = f"idiosyncratic_risk must have shape ({assets},) to match exposure, got {idiosyncratic_risk.shape}"
+            raise ValueError(msg)
 
-        self.parameter["exposure"].value[:k, :assets] = kwargs["exposure"]
-        self.parameter["idiosyncratic_risk"].value[:assets] = kwargs["idiosyncratic_risk"]
-        self.parameter["chol"].value[:k, :k] = cholesky(kwargs["cov"])
+        self.parameter["exposure"].value = np.zeros((self.k, self.assets))
+        self.parameter["chol"].value = np.zeros((self.k, self.k))
+        self.parameter["idiosyncratic_risk"].value = np.zeros(self.assets)
+
+        self.parameter["exposure"].value[:k, :assets] = exposure
+        self.parameter["idiosyncratic_risk"].value[:assets] = idiosyncratic_risk
+        self.parameter["chol"].value[:k, :k] = cholesky(cov)
         self.bounds_assets.update(**kwargs)
         self.bounds_factors.update(**kwargs)
 
@@ -306,8 +312,17 @@ class FactorModel(Model):
         extra_constraints: list[tuple[np.ndarray, float | None, float | None]],
         y_var: Variable | None = None,
     ) -> tuple[float | None, float | None, str]:
-        """Build and solve the Clarabel SOC problem for this model."""
+        """Build and solve the Clarabel SOC problem for this model.
+
+        Raises:
+            ValueError: If the weights dimension does not match the model
+                capacity ``assets``.
+
+        """
         n = weights.n
+        if n != self.assets:
+            msg = f"weights has dimension {n} but the model capacity is assets={self.assets}"
+            raise ValueError(msg)
         k = self.k
 
         chol = self.parameter["chol"].value
@@ -317,96 +332,48 @@ class FactorModel(Model):
         lb_w, ub_w = self.bounds_assets.get_bounds()
         lb_y, ub_y = self.bounds_factors.get_bounds()
 
-        n_vars = 1 + n + k
-        P = sparse.csc_matrix((n_vars, n_vars))  # noqa: N806
-        q = np.zeros(n_vars)
-        q[0] = 1.0
+        # Variables: x = [t, w, y] with t bounding the total volatility
+        # and y the factor exposures.
+        w_cols = slice(1, 1 + n)
+        y_cols = slice(1 + n, 1 + n + k)
+        builder = ConeProgramBuilder(n_vars=1 + n + k)
 
-        A_rows: list[np.ndarray] = []  # noqa: N806
-        b_rows: list[np.ndarray] = []
-        cones: list[Any] = []
-
+        # SOC: || [chol @ exposure @ (w - base); idio * (w - base)] ||_2 <= t
+        # encoded via y = exposure @ w, so the systematic term is chol @ (y - exposure @ base).
+        # Built directly in sparse form: the block has only O(n + k^2) nonzeros.
         soc_size = 1 + k + n
-        A_soc = np.zeros((soc_size, n_vars))  # noqa: N806
-        A_soc[0, 0] = -1.0
-        A_soc[1 : 1 + k, 1 + n :] = -chol
-        A_soc[1 + k :, 1 : 1 + n] = -np.diag(idio)
+        a_soc = sparse.bmat(
+            [
+                [sparse.csr_matrix(np.array([[-1.0]])), None, None],
+                [None, None, sparse.csr_matrix(-chol)],
+                [None, sparse.diags(-idio), None],
+            ],
+            format="csr",
+        )
         b_soc = np.zeros(soc_size)
+        b_soc[1 : 1 + k] = -chol @ (exposure @ base)
         b_soc[1 + k :] = -idio * base
-        A_rows.append(A_soc)
-        b_rows.append(b_soc)
-        cones.append(clarabel.SecondOrderConeT(soc_size))
+        builder.add(a_soc, b_soc, clarabel.SecondOrderConeT(soc_size))
 
-        A_eq_sum = np.zeros((1, n_vars))  # noqa: N806
-        A_eq_sum[0, 1 : 1 + n] = 1.0
-        A_rows.append(A_eq_sum)
-        b_rows.append(np.array([1.0]))
-        cones.append(clarabel.ZeroConeT(1))
+        builder.add_sum_constraint(w_cols)
 
-        A_eq_exp = np.zeros((k, n_vars))  # noqa: N806
-        A_eq_exp[:, 1 : 1 + n] = -exposure
-        A_eq_exp[:, 1 + n :] = np.eye(k)
-        A_rows.append(A_eq_exp)
-        b_rows.append(np.zeros(k))
-        cones.append(clarabel.ZeroConeT(k))
+        # Equality: y = exposure @ w
+        a_exp = builder.block(k)
+        a_exp[:, w_cols] = -exposure
+        a_exp[:, y_cols] = np.eye(k)
+        builder.add(a_exp, np.zeros(k), clarabel.ZeroConeT(k))
 
-        A_wlb = np.zeros((n, n_vars))  # noqa: N806
-        A_wlb[:, 1 : 1 + n] = -np.eye(n)
-        A_rows.append(A_wlb)
-        b_rows.append(-lb_w)
-        cones.append(clarabel.NonnegativeConeT(n))
+        builder.add_variable_bounds(w_cols, lb_w, ub_w)
+        builder.add_variable_bounds(y_cols, lb_y, ub_y)
+        builder.add_linear_constraints(extra_constraints, w_cols)
 
-        A_wub = np.zeros((n, n_vars))  # noqa: N806
-        A_wub[:, 1 : 1 + n] = np.eye(n)
-        A_rows.append(A_wub)
-        b_rows.append(ub_w)
-        cones.append(clarabel.NonnegativeConeT(n))
-
-        A_ylb = np.zeros((k, n_vars))  # noqa: N806
-        A_ylb[:, 1 + n :] = -np.eye(k)
-        A_rows.append(A_ylb)
-        b_rows.append(-lb_y)
-        cones.append(clarabel.NonnegativeConeT(k))
-
-        A_yub = np.zeros((k, n_vars))  # noqa: N806
-        A_yub[:, 1 + n :] = np.eye(k)
-        A_rows.append(A_yub)
-        b_rows.append(ub_y)
-        cones.append(clarabel.NonnegativeConeT(k))
-
-        for a, lb_val, ub_val in extra_constraints:
-            a = np.asarray(a)
-            if lb_val is not None and ub_val is not None and lb_val == ub_val:
-                A_extra = np.zeros((1, n_vars))  # noqa: N806
-                A_extra[0, 1 : 1 + n] = a
-                A_rows.append(A_extra)
-                b_rows.append(np.array([lb_val]))
-                cones.append(clarabel.ZeroConeT(1))
-            else:
-                if lb_val is not None:
-                    A_extra = np.zeros((1, n_vars))  # noqa: N806
-                    A_extra[0, 1 : 1 + n] = -a
-                    A_rows.append(A_extra)
-                    b_rows.append(np.array([-lb_val]))
-                    cones.append(clarabel.NonnegativeConeT(1))
-                if ub_val is not None:
-                    A_extra = np.zeros((1, n_vars))  # noqa: N806
-                    A_extra[0, 1 : 1 + n] = a
-                    A_rows.append(A_extra)
-                    b_rows.append(np.array([ub_val]))
-                    cones.append(clarabel.NonnegativeConeT(1))
-
-        A = sparse.csc_matrix(np.vstack(A_rows))  # noqa: N806
-        b = np.concatenate(b_rows)
-
-        settings = clarabel.DefaultSettings()
-        settings.verbose = False
-        sol = clarabel.DefaultSolver(P, q, A, b, cones, settings).solve()
-        status = str(sol.status)
+        q = np.zeros(builder.n_vars)
+        q[0] = 1.0
+        sol, status = builder.solve(q)
 
         if "Solved" in status:
-            weights.value = np.array(sol.x[1 : 1 + n])
+            weights.value = np.array(sol.x[w_cols])
             if y_var is not None:
-                y_var.value = np.array(sol.x[1 + n : 1 + n + k])
+                y_var.value = np.array(sol.x[y_cols])
             return float(sol.obj_val), float(sol.x[0]), status
         return None, None, status

--- a/src/cvx/risk/portfolio/__init__.py
+++ b/src/cvx/risk/portfolio/__init__.py
@@ -24,18 +24,9 @@ Functions:
     minrisk_problem: Create a minimum-risk portfolio optimization problem
 
 """
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 
 from .min_risk import minrisk_problem as minrisk_problem

--- a/src/cvx/risk/portfolio/min_risk.py
+++ b/src/cvx/risk/portfolio/min_risk.py
@@ -29,19 +29,10 @@ Example:
 
 """
 
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -143,6 +134,12 @@ class MinRiskProblem:
 
         After calling ``solve()``, you can update the model parameters and call
         ``solve()`` again without reconstructing the problem structure.
+
+        Failure contract: ``solve()`` does not raise when the problem cannot be
+        solved (e.g. it is infeasible or unbounded). Instead, ``status`` is set
+        to the solver status, ``value`` stays ``None``, and ``weights.value``
+        is left untouched. Always check ``status`` (or ``value is not None``)
+        before using the weights.
 
         Example:
             >>> import numpy as np

--- a/src/cvx/risk/sample/__init__.py
+++ b/src/cvx/risk/sample/__init__.py
@@ -21,17 +21,8 @@ Classes:
 
 """
 
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 from .sample import SampleCovariance as SampleCovariance

--- a/src/cvx/risk/sample/sample.py
+++ b/src/cvx/risk/sample/sample.py
@@ -1,16 +1,7 @@
-#    Copyright 2023 Stanford University Convex Optimization Group
+#    Copyright (c) 2025 Jebel Quant Research
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#    Licensed under the MIT License. See the LICENSE file in the project root
+#    for the full license text.
 """Risk models based on the sample covariance matrix.
 
 This module provides the SampleCovariance class, which implements a risk model
@@ -47,9 +38,8 @@ from typing import Any
 import clarabel
 import numpy as np
 from cvx.linalg import cholesky, norm
-from scipy import sparse
 
-from cvx.core import Bounds, Model, Parameter, Variable
+from cvx.core import Bounds, ConeProgramBuilder, Model, Parameter, Variable
 
 
 @dataclass
@@ -186,6 +176,10 @@ class SampleCovariance(Model):
                 - lower_assets: Array of lower bounds for asset weights.
                 - upper_assets: Array of upper bounds for asset weights.
 
+        Raises:
+            ValueError: If ``cov`` is missing, not square, or larger than the
+                model capacity ``num``.
+
         Example:
             >>> import numpy as np
             >>> from cvx.risk.sample import SampleCovariance
@@ -204,7 +198,16 @@ class SampleCovariance(Model):
             (3, 3)
 
         """
-        cov = kwargs["cov"]
+        if "cov" not in kwargs:
+            msg = "update() requires a 'cov' argument"
+            raise ValueError(msg)
+        cov = np.asarray(kwargs["cov"])
+        if cov.ndim != 2 or cov.shape[0] != cov.shape[1]:
+            msg = f"cov must be a square matrix, got shape {cov.shape}"
+            raise ValueError(msg)
+        if cov.shape[0] > self.num:
+            msg = f"Too many assets: cov is {cov.shape[0]}x{cov.shape[0]} but the model capacity is num={self.num}"
+            raise ValueError(msg)
         n = cov.shape[0]
 
         chol = np.zeros((self.num, self.num))
@@ -219,78 +222,41 @@ class SampleCovariance(Model):
         extra_constraints: list[tuple[np.ndarray, float | None, float | None]],
         y_var: Variable | None = None,
     ) -> tuple[float | None, float | None, str]:
-        """Build and solve the Clarabel SOC problem for this model."""
+        """Build and solve the Clarabel SOC problem for this model.
+
+        Raises:
+            ValueError: If the weights dimension does not match the model
+                capacity ``num``.
+
+        """
         n = weights.n
+        if n != self.num:
+            msg = f"weights has dimension {n} but the model capacity is num={self.num}"
+            raise ValueError(msg)
         chol = self.parameter["chol"].value
         lb, ub = self.bounds.get_bounds()
 
-        n_vars = 1 + n
-        P = sparse.csc_matrix((n_vars, n_vars))  # noqa: N806
-        q = np.zeros(n_vars)
-        q[0] = 1.0
+        # Variables: x = [t, w] with t bounding the portfolio volatility.
+        w_cols = slice(1, 1 + n)
+        builder = ConeProgramBuilder(n_vars=1 + n)
 
-        A_rows: list[np.ndarray] = []  # noqa: N806
-        b_rows: list[np.ndarray] = []
-        cones: list[Any] = []
-
-        A_soc = np.zeros((n + 1, n_vars))  # noqa: N806
-        A_soc[0, 0] = -1.0
-        A_soc[1:, 1:] = -chol
+        # SOC: || chol @ (w - base) ||_2 <= t
+        a_soc = builder.block(n + 1)
+        a_soc[0, 0] = -1.0
+        a_soc[1:, w_cols] = -chol
         b_soc = np.zeros(n + 1)
         b_soc[1:] = -chol @ base
-        A_rows.append(A_soc)
-        b_rows.append(b_soc)
-        cones.append(clarabel.SecondOrderConeT(n + 1))
+        builder.add(a_soc, b_soc, clarabel.SecondOrderConeT(n + 1))
 
-        A_eq = np.zeros((1, n_vars))  # noqa: N806
-        A_eq[0, 1:] = 1.0
-        A_rows.append(A_eq)
-        b_rows.append(np.array([1.0]))
-        cones.append(clarabel.ZeroConeT(1))
+        builder.add_sum_constraint(w_cols)
+        builder.add_variable_bounds(w_cols, lb, ub)
+        builder.add_linear_constraints(extra_constraints, w_cols)
 
-        A_lb = np.zeros((n, n_vars))  # noqa: N806
-        A_lb[:, 1:] = -np.eye(n)
-        A_rows.append(A_lb)
-        b_rows.append(-lb)
-        cones.append(clarabel.NonnegativeConeT(n))
-
-        A_ub = np.zeros((n, n_vars))  # noqa: N806
-        A_ub[:, 1:] = np.eye(n)
-        A_rows.append(A_ub)
-        b_rows.append(ub)
-        cones.append(clarabel.NonnegativeConeT(n))
-
-        for a, lb_val, ub_val in extra_constraints:
-            a = np.asarray(a)
-            if lb_val is not None and ub_val is not None and lb_val == ub_val:
-                A_extra = np.zeros((1, n_vars))  # noqa: N806
-                A_extra[0, 1:] = a
-                A_rows.append(A_extra)
-                b_rows.append(np.array([lb_val]))
-                cones.append(clarabel.ZeroConeT(1))
-            else:
-                if lb_val is not None:
-                    A_extra = np.zeros((1, n_vars))  # noqa: N806
-                    A_extra[0, 1:] = -a
-                    A_rows.append(A_extra)
-                    b_rows.append(np.array([-lb_val]))
-                    cones.append(clarabel.NonnegativeConeT(1))
-                if ub_val is not None:
-                    A_extra = np.zeros((1, n_vars))  # noqa: N806
-                    A_extra[0, 1:] = a
-                    A_rows.append(A_extra)
-                    b_rows.append(np.array([ub_val]))
-                    cones.append(clarabel.NonnegativeConeT(1))
-
-        A = sparse.csc_matrix(np.vstack(A_rows))  # noqa: N806
-        b = np.concatenate(b_rows)
-
-        settings = clarabel.DefaultSettings()
-        settings.verbose = False
-        sol = clarabel.DefaultSolver(P, q, A, b, cones, settings).solve()
-        status = str(sol.status)
+        q = np.zeros(builder.n_vars)
+        q[0] = 1.0
+        sol, status = builder.solve(q)
 
         if "Solved" in status:
-            weights.value = np.array(sol.x[1 : 1 + n])
+            weights.value = np.array(sol.x[w_cols])
             return float(sol.obj_val), float(sol.x[0]), status
         return None, None, status

--- a/tests/risk/test_contracts.py
+++ b/tests/risk/test_contracts.py
@@ -1,0 +1,166 @@
+"""Tests pinning API contracts surfaced by mutation testing.
+
+Each test here kills a mutant that survived the initial mutation-testing run:
+constructor defaults, the documented ``y`` keyword of ``FactorModel.estimate``,
+dimension-violation error messages, and the (objective, risk, status) return
+contract of ``solve_minrisk``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cvx.core import Bounds, Model, Variable
+from cvx.risk.cvar import CVar
+from cvx.risk.factor import FactorModel
+from cvx.risk.portfolio.min_risk import MinRiskProblem
+from cvx.risk.sample import SampleCovariance
+
+
+def test_constructor_defaults():
+    """The documented dataclass defaults are part of the public API."""
+    assert SampleCovariance().num == 0
+    assert FactorModel().assets == 0
+    assert FactorModel().k == 0
+    cvar = CVar()
+    assert cvar.alpha == 0.95
+    assert cvar.n == 0
+    assert cvar.m == 0
+    bounds = Bounds()
+    assert bounds.m == 0
+    assert bounds.name == ""
+
+
+def test_model_is_abstract():
+    """Both estimate and update must be abstract: implementing only one is not enough."""
+    with pytest.raises(TypeError):
+        Model()
+
+    class OnlyEstimate(Model):
+        def estimate(self, weights, **kwargs):
+            return 0.0
+
+    class OnlyUpdate(Model):
+        def update(self, **kwargs):
+            pass
+
+    with pytest.raises(TypeError):
+        OnlyEstimate()
+    with pytest.raises(TypeError):
+        OnlyUpdate()
+
+
+def test_minrisk_problem_pads_short_base():
+    """A base portfolio shorter than the weights vector must be zero-padded."""
+    n = 3
+    model = SampleCovariance(num=n)
+    cov = np.array([[1.0, 0.2, 0.1], [0.2, 1.5, 0.3], [0.1, 0.3, 2.0]])
+    model.update(cov=cov, lower_assets=np.zeros(n), upper_assets=np.ones(n))
+
+    weights_short = Variable(n)
+    problem_short = MinRiskProblem(riskmodel=model, weights=weights_short, base=np.array([0.5, 0.5]))
+    problem_short.solve()
+    assert "Solved" in problem_short.status
+
+    weights_padded = Variable(n)
+    problem_padded = MinRiskProblem(riskmodel=model, weights=weights_padded, base=np.array([0.5, 0.5, 0.0]))
+    problem_padded.solve()
+    assert "Solved" in problem_padded.status
+
+    assert np.isclose(problem_short.value, problem_padded.value, rtol=1e-9)
+    assert np.allclose(np.array(weights_short.value), np.array(weights_padded.value), atol=1e-7)
+
+
+def test_minrisk_problem_direct_construction():
+    """MinRiskProblem must be usable directly with its field defaults (no base, no constraints)."""
+    n = 2
+    model = SampleCovariance(num=n)
+    model.update(
+        cov=np.array([[1.0, 0.5], [0.5, 2.0]]),
+        lower_assets=np.zeros(n),
+        upper_assets=np.ones(n),
+    )
+    weights = Variable(n)
+    problem = MinRiskProblem(riskmodel=model, weights=weights)
+    problem.solve()
+
+    assert "Solved" in problem.status
+    assert np.isclose(np.sum(np.array(weights.value)), 1.0, atol=1e-6)
+
+
+def test_factor_estimate_uses_explicit_y():
+    """An explicitly passed ``y`` must be used instead of exposure @ weights."""
+    n, k = 3, 2
+    model = FactorModel(assets=n, k=k)
+    exposure = np.array([[1.0, 0.5, 0.0], [0.0, 0.5, 1.0]])
+    model.update(
+        exposure=exposure,
+        cov=np.eye(k),
+        idiosyncratic_risk=0.1 * np.ones(n),
+        lower_assets=np.zeros(n),
+        upper_assets=np.ones(n),
+        lower_factors=-np.ones(k),
+        upper_factors=np.ones(k),
+    )
+    w = np.array([0.4, 0.3, 0.3])
+    custom_y = np.array([10.0, -10.0])
+
+    default_risk = model.estimate(w)
+    custom_risk = model.estimate(w, y=custom_y)
+    expected_custom = np.sqrt(custom_y @ custom_y + np.sum((0.1 * w) ** 2))
+
+    assert not np.isclose(default_risk, custom_risk)
+    assert np.isclose(custom_risk, expected_custom, rtol=1e-8)
+
+
+def test_factor_update_rejects_too_many_assets():
+    """Exceeding the asset capacity must raise with the documented message."""
+    model = FactorModel(assets=2, k=2)
+    with pytest.raises(ValueError, match=r"^Too many assets$"):
+        model.update(
+            exposure=np.ones((2, 5)),  # 5 assets > capacity of 2
+            cov=np.eye(2),
+            idiosyncratic_risk=np.ones(5),
+            lower_assets=np.zeros(5),
+            upper_assets=np.ones(5),
+            lower_factors=-np.ones(2),
+            upper_factors=np.ones(2),
+        )
+
+
+@pytest.mark.parametrize("model_name", ["sample", "factor"])
+def test_solve_minrisk_returns_achieved_risk(model_name):
+    """The risk element of (objective, risk, status) must equal the optimal objective.
+
+    For the minimum-risk problems the objective *is* the portfolio risk, so the
+    second element must match the first (and not, say, a stray solution entry).
+    """
+    n, k = 4, 2
+    rng = np.random.default_rng(42)
+    if model_name == "sample":
+        g = rng.standard_normal((n, n))
+        model = SampleCovariance(num=n)
+        model.update(
+            cov=g.T @ g / n + 0.1 * np.eye(n),
+            lower_assets=np.zeros(n),
+            upper_assets=np.ones(n),
+        )
+    else:
+        model = FactorModel(assets=n, k=k)
+        model.update(
+            exposure=rng.standard_normal((k, n)),
+            cov=np.eye(k),
+            idiosyncratic_risk=rng.uniform(0.05, 0.2, n),
+            lower_assets=np.zeros(n),
+            upper_assets=np.ones(n),
+            lower_factors=-100 * np.ones(k),
+            upper_factors=100 * np.ones(k),
+        )
+
+    weights = Variable(n)
+    objective, risk, status = model.solve_minrisk(weights, np.zeros(n), [])
+
+    assert "Solved" in status
+    assert np.isclose(risk, objective, rtol=1e-9)
+    assert np.isclose(risk, model.estimate(np.array(weights.value)), rtol=1e-6)

--- a/tests/risk/test_cvxpy_equivalence.py
+++ b/tests/risk/test_cvxpy_equivalence.py
@@ -1,0 +1,81 @@
+"""Equivalence tests against cvxpy reference formulations.
+
+These tests require cvxpy (available via ``uv sync --group benchmark``) and
+are skipped when it is not installed. They check that the hand-built Clarabel
+conic programs match what cvxpy produces for the same mathematical problem,
+including the base-portfolio (tracking error) variant.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cvx.core import Variable
+from cvx.risk.cvar import CVar
+from cvx.risk.portfolio import minrisk_problem
+from cvx.risk.sample import SampleCovariance
+
+cp = pytest.importorskip("cvxpy")
+
+
+def random_covariance(rng: np.random.Generator, n: int) -> np.ndarray:
+    """Return a random strictly positive definite covariance matrix."""
+    g = rng.standard_normal((n, n))
+    return g.T @ g / n + 0.1 * np.eye(n)
+
+
+@pytest.mark.parametrize("seed", range(3))
+@pytest.mark.parametrize("use_base", [False, True])
+def test_sample_minrisk_matches_cvxpy(seed, use_base):
+    """The direct SOC program must match the cvxpy formulation of min ||chol (w - base)||."""
+    n = 6
+    rng = np.random.default_rng(seed)
+    cov = random_covariance(rng, n)
+    base = rng.dirichlet(np.ones(n)) if use_base else np.zeros(n)
+
+    model = SampleCovariance(num=n)
+    model.update(cov=cov, lower_assets=np.zeros(n), upper_assets=np.ones(n))
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights, base=base if use_base else 0.0)
+    problem.solve()
+    assert "Solved" in problem.status
+
+    chol = np.linalg.cholesky(cov).T
+    w = cp.Variable(n)
+    reference = cp.Problem(
+        cp.Minimize(cp.norm(chol @ (w - base), 2)),
+        [cp.sum(w) == 1, w >= 0, w <= 1],
+    )
+    reference.solve(solver="CLARABEL")
+
+    assert np.isclose(problem.value, reference.value, rtol=1e-6, atol=1e-8)
+    assert np.allclose(np.array(weights.value), w.value, atol=1e-5)
+
+
+@pytest.mark.parametrize("seed", range(3))
+def test_cvar_minrisk_matches_cvxpy(seed):
+    """The direct CVaR LP must match the cvxpy Rockafellar-Uryasev formulation."""
+    n_scenarios, m, alpha = 50, 5, 0.9
+    rng = np.random.default_rng(seed)
+    returns = rng.standard_normal((n_scenarios, m)) * 0.02
+
+    model = CVar(alpha=alpha, n=n_scenarios, m=m)
+    model.update(returns=returns, lower_assets=np.zeros(m), upper_assets=np.ones(m))
+    weights = Variable(m)
+    problem = minrisk_problem(model, weights)
+    problem.solve()
+    assert "Solved" in problem.status
+
+    k = model.k
+    w = cp.Variable(m)
+    gamma = cp.Variable()
+    u = cp.Variable(n_scenarios)
+    reference = cp.Problem(
+        cp.Minimize(gamma + cp.sum(u) / k),
+        [u >= -returns @ w - gamma, u >= 0, cp.sum(w) == 1, w >= 0, w <= 1],
+    )
+    reference.solve(solver="CLARABEL")
+
+    assert np.isclose(problem.value, reference.value, rtol=1e-6, atol=1e-8)
+    assert np.isclose(model.estimate(np.array(weights.value)), reference.value, rtol=1e-5, atol=1e-6)

--- a/tests/risk/test_failure_paths.py
+++ b/tests/risk/test_failure_paths.py
@@ -1,0 +1,201 @@
+"""Tests pinning down the behavior of infeasible problems and invalid inputs.
+
+The documented contract on failure is: ``problem.status`` reports the solver
+status, ``problem.value`` stays ``None``, and ``weights.value`` is not
+populated. These tests make that contract explicit for each model, and pin
+the current behavior for degenerate covariance input.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cvx.core import Variable
+from cvx.risk.cvar import CVar
+from cvx.risk.factor import FactorModel
+from cvx.risk.portfolio import minrisk_problem
+from cvx.risk.sample import SampleCovariance
+
+
+def assert_solve_failed(problem, weights):
+    """Assert the documented failure contract: no value, no weights, informative status."""
+    assert problem.status is not None
+    assert "Solved" not in problem.status
+    assert problem.value is None
+    assert weights.value is None
+
+
+def test_sample_infeasible_bounds():
+    """Bounds that cannot sum to one must yield an infeasible status, not garbage weights."""
+    n = 3
+    model = SampleCovariance(num=n)
+    model.update(
+        cov=np.eye(n),
+        lower_assets=np.zeros(n),
+        upper_assets=np.full(n, 0.2),  # sum of upper bounds < 1
+    )
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights)
+    problem.solve()
+    assert_solve_failed(problem, weights)
+
+
+def test_sample_contradictory_extra_constraint():
+    """An extra constraint contradicting sum(w) == 1 must be reported as infeasible."""
+    n = 3
+    model = SampleCovariance(num=n)
+    model.update(cov=np.eye(n), lower_assets=np.zeros(n), upper_assets=np.ones(n))
+    weights = Variable(n)
+    # sum(w) == 2 contradicts the built-in budget constraint sum(w) == 1.
+    problem = minrisk_problem(model, weights, constraints=[(np.ones(n), 2.0, 2.0)])
+    problem.solve()
+    assert_solve_failed(problem, weights)
+
+
+def test_cvar_infeasible_bounds():
+    """The CVaR LP must report infeasibility for contradictory weight bounds."""
+    n_scenarios, m = 30, 3
+    model = CVar(alpha=0.9, n=n_scenarios, m=m)
+    model.update(
+        returns=np.random.default_rng(0).standard_normal((n_scenarios, m)),
+        lower_assets=np.full(m, 0.6),  # sum of lower bounds > 1
+        upper_assets=np.ones(m),
+    )
+    weights = Variable(m)
+    problem = minrisk_problem(model, weights)
+    problem.solve()
+    assert_solve_failed(problem, weights)
+
+
+def test_factor_infeasible_factor_bounds():
+    """Factor exposure bounds that exclude all simplex portfolios must be infeasible."""
+    n, k = 3, 2
+    model = FactorModel(assets=n, k=k)
+    model.update(
+        exposure=np.ones((k, n)),
+        cov=np.eye(k),
+        idiosyncratic_risk=0.1 * np.ones(n),
+        lower_assets=np.zeros(n),
+        upper_assets=np.ones(n),
+        # Any w on the simplex has exposure y = 1 per factor; force y <= 0.5.
+        lower_factors=-np.ones(k),
+        upper_factors=0.5 * np.ones(k),
+    )
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights)
+    problem.solve()
+    assert_solve_failed(problem, weights)
+
+
+def test_singular_covariance_raises():
+    """A rank-deficient covariance matrix raises LinAlgError from the Cholesky factorization.
+
+    This pins the current behavior so any future change (e.g. a regularized
+    fallback) is a conscious decision.
+    """
+    n = 2
+    model = SampleCovariance(num=n)
+    with pytest.raises(np.linalg.LinAlgError):
+        model.update(
+            cov=np.ones((n, n)),  # rank 1
+            lower_assets=np.zeros(n),
+            upper_assets=np.ones(n),
+        )
+
+
+def test_update_validation_messages():
+    """Invalid update() inputs must raise ValueError with actionable messages."""
+    sample = SampleCovariance(num=3)
+    with pytest.raises(ValueError, match="requires a 'cov'"):
+        sample.update(lower_assets=np.zeros(3), upper_assets=np.ones(3))
+    with pytest.raises(ValueError, match="square"):
+        sample.update(cov=np.ones((2, 3)), lower_assets=np.zeros(3), upper_assets=np.ones(3))
+    with pytest.raises(ValueError, match="Too many assets"):
+        sample.update(cov=np.eye(4), lower_assets=np.zeros(4), upper_assets=np.ones(4))
+    with pytest.raises(ValueError, match="requires a 'lower_assets'"):
+        sample.update(cov=np.eye(3), lower_asset=np.zeros(3), upper_assets=np.ones(3))  # typo
+
+    factor = FactorModel(assets=3, k=2)
+    with pytest.raises(ValueError, match="missing required arguments: cov"):
+        factor.update(
+            exposure=np.ones((2, 3)),
+            idiosyncratic_risk=np.ones(3),
+            lower_assets=np.zeros(3),
+            upper_assets=np.ones(3),
+            lower_factors=-np.ones(2),
+            upper_factors=np.ones(2),
+        )
+    with pytest.raises(ValueError, match="cov must have shape"):
+        factor.update(
+            exposure=np.ones((2, 3)),
+            cov=np.eye(3),  # should be 2x2
+            idiosyncratic_risk=np.ones(3),
+            lower_assets=np.zeros(3),
+            upper_assets=np.ones(3),
+            lower_factors=-np.ones(2),
+            upper_factors=np.ones(2),
+        )
+    with pytest.raises(ValueError, match="idiosyncratic_risk must have shape"):
+        factor.update(
+            exposure=np.ones((2, 3)),
+            cov=np.eye(2),
+            idiosyncratic_risk=np.ones(2),  # should have length 3
+            lower_assets=np.zeros(3),
+            upper_assets=np.ones(3),
+            lower_factors=-np.ones(2),
+            upper_factors=np.ones(2),
+        )
+
+    cvar = CVar(alpha=0.9, n=10, m=3)
+    with pytest.raises(ValueError, match="requires a 'returns'"):
+        cvar.update(lower_assets=np.zeros(3), upper_assets=np.ones(3))
+    with pytest.raises(ValueError, match=r"expects n=10"):
+        cvar.update(returns=np.zeros((5, 3)), lower_assets=np.zeros(3), upper_assets=np.ones(3))
+    with pytest.raises(ValueError, match="Too many assets"):
+        cvar.update(returns=np.zeros((10, 4)), lower_assets=np.zeros(4), upper_assets=np.ones(4))
+
+
+def test_solve_minrisk_dimension_mismatch():
+    """A weights variable that does not fit the model must raise a clear error."""
+    sample = SampleCovariance(num=3)
+    sample.update(cov=np.eye(3), lower_assets=np.zeros(3), upper_assets=np.ones(3))
+    problem = minrisk_problem(sample, Variable(2))
+    with pytest.raises(ValueError, match="capacity is num=3"):
+        problem.solve()
+
+    factor = FactorModel(assets=3, k=2)
+    factor.update(
+        exposure=np.ones((2, 3)),
+        cov=np.eye(2),
+        idiosyncratic_risk=np.ones(3),
+        lower_assets=np.zeros(3),
+        upper_assets=np.ones(3),
+        lower_factors=-np.ones(2),
+        upper_factors=np.ones(2),
+    )
+    problem = minrisk_problem(factor, Variable(4))
+    with pytest.raises(ValueError, match="capacity is assets=3"):
+        problem.solve()
+
+    cvar = CVar(alpha=0.9, n=10, m=3)
+    cvar.update(returns=np.zeros((10, 3)), lower_assets=np.zeros(3), upper_assets=np.ones(3))
+    problem = minrisk_problem(cvar, Variable(4))
+    with pytest.raises(ValueError, match="capacity is m=3"):
+        problem.solve()
+
+
+def test_resolve_after_infeasible_recovers():
+    """After an infeasible solve, fixing the bounds and re-solving must succeed."""
+    n = 3
+    model = SampleCovariance(num=n)
+    model.update(cov=np.eye(n), lower_assets=np.zeros(n), upper_assets=np.full(n, 0.2))
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights)
+    problem.solve()
+    assert "Solved" not in problem.status
+
+    model.update(cov=np.eye(n), lower_assets=np.zeros(n), upper_assets=np.ones(n))
+    problem.solve()
+    assert "Solved" in problem.status
+    assert np.isclose(np.sum(np.array(weights.value)), 1.0, atol=1e-6)

--- a/tests/risk/test_properties.py
+++ b/tests/risk/test_properties.py
@@ -1,0 +1,132 @@
+"""Property-based tests for the risk models using Hypothesis.
+
+Each test states a mathematical invariant the models must satisfy for *any*
+valid input, and Hypothesis searches for counterexamples:
+
+- SampleCovariance.estimate equals the quadratic form sqrt(w' cov w).
+- FactorModel.estimate equals the sample-covariance risk of the reconstructed
+  covariance matrix beta' cov_f beta + diag(idio^2).
+- CVar.estimate equals the negated mean of the k worst scenario returns.
+- Minimum-risk solutions are feasible and no feasible portfolio beats them.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+from cvx.core import Variable
+from cvx.risk.cvar import CVar
+from cvx.risk.factor import FactorModel
+from cvx.risk.portfolio import minrisk_problem
+from cvx.risk.sample import SampleCovariance
+
+pytestmark = pytest.mark.property
+
+
+@st.composite
+def covariance_matrices(draw, n: int) -> np.ndarray:
+    """Draw a strictly positive definite n x n covariance matrix."""
+    g = draw(hnp.arrays(np.float64, (n, n), elements=st.floats(-2.0, 2.0)))
+    return g.T @ g + 0.5 * np.eye(n)
+
+
+@settings(max_examples=50, deadline=None)
+@given(data=st.data())
+def test_sample_estimate_is_quadratic_form(data):
+    """SampleCovariance.estimate(w) must equal sqrt(w' cov w) for any w."""
+    n = data.draw(st.integers(2, 8), label="n")
+    cov = data.draw(covariance_matrices(n), label="cov")
+    w = data.draw(hnp.arrays(np.float64, (n,), elements=st.floats(-1.0, 1.0)), label="w")
+
+    model = SampleCovariance(num=n)
+    model.update(cov=cov, lower_assets=np.zeros(n), upper_assets=np.ones(n))
+
+    expected = np.sqrt(w @ cov @ w)
+    assert np.isclose(model.estimate(w), expected, rtol=1e-8, atol=1e-10)
+
+
+@settings(max_examples=50, deadline=None)
+@given(data=st.data())
+def test_factor_estimate_matches_reconstructed_covariance(data):
+    """FactorModel risk must equal the full-covariance risk of beta' cov_f beta + diag(idio^2)."""
+    n = data.draw(st.integers(2, 8), label="assets")
+    k = data.draw(st.integers(1, 4), label="factors")
+    cov_f = data.draw(covariance_matrices(k), label="factor cov")
+    exposure = data.draw(hnp.arrays(np.float64, (k, n), elements=st.floats(-1.0, 1.0)), label="exposure")
+    idio = data.draw(hnp.arrays(np.float64, (n,), elements=st.floats(0.01, 1.0)), label="idio")
+    w = data.draw(hnp.arrays(np.float64, (n,), elements=st.floats(-1.0, 1.0)), label="w")
+
+    model = FactorModel(assets=n, k=k)
+    model.update(
+        exposure=exposure,
+        cov=cov_f,
+        idiosyncratic_risk=idio,
+        lower_assets=np.zeros(n),
+        upper_assets=np.ones(n),
+        lower_factors=-np.ones(k),
+        upper_factors=np.ones(k),
+    )
+
+    reconstructed = exposure.T @ cov_f @ exposure + np.diag(idio**2)
+    expected = np.sqrt(w @ reconstructed @ w)
+    assert np.isclose(model.estimate(w), expected, rtol=1e-8, atol=1e-10)
+
+
+@settings(max_examples=50, deadline=None)
+@given(data=st.data())
+def test_cvar_estimate_is_tail_mean(data):
+    """CVar.estimate(w) must equal the negated mean of the k smallest scenario returns."""
+    n_scenarios = data.draw(st.integers(20, 60), label="scenarios")
+    m_max = data.draw(st.integers(2, 6), label="max assets")
+    # Use fewer assets than the model capacity to exercise the padding logic.
+    m_used = data.draw(st.integers(2, m_max), label="used assets")
+    alpha = data.draw(st.sampled_from([0.8, 0.9, 0.95]), label="alpha")
+    returns = data.draw(
+        hnp.arrays(np.float64, (n_scenarios, m_used), elements=st.floats(-1.0, 1.0)),
+        label="returns",
+    )
+    w = data.draw(hnp.arrays(np.float64, (m_used,), elements=st.floats(0.0, 1.0)), label="w")
+
+    model = CVar(alpha=alpha, n=n_scenarios, m=m_max)
+    model.update(returns=returns, lower_assets=np.zeros(m_used), upper_assets=np.ones(m_used))
+
+    k = int(n_scenarios * (1 - alpha))
+    padded_w = np.zeros(m_max)
+    padded_w[:m_used] = w
+    expected = -np.mean(np.sort(returns @ w)[:k])
+    assert np.isclose(model.estimate(padded_w), expected, rtol=1e-8, atol=1e-10)
+
+
+@settings(max_examples=25, deadline=None)
+@given(data=st.data())
+def test_minrisk_solution_is_feasible_and_optimal(data):
+    """The minimum-risk portfolio must be feasible, and no feasible portfolio may have lower risk."""
+    n = data.draw(st.integers(2, 6), label="n")
+    cov = data.draw(covariance_matrices(n), label="cov")
+    seed = data.draw(st.integers(0, 2**32 - 1), label="seed")
+
+    model = SampleCovariance(num=n)
+    model.update(cov=cov, lower_assets=np.zeros(n), upper_assets=np.ones(n))
+
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights)
+    problem.solve()
+
+    assert "Solved" in problem.status
+    w_opt = np.array(weights.value)
+
+    # Feasibility (allowing for solver tolerance).
+    assert np.isclose(np.sum(w_opt), 1.0, atol=1e-6)
+    assert np.all(w_opt >= -1e-6)
+    assert np.all(w_opt <= 1.0 + 1e-6)
+
+    # Optimality: random points on the simplex must not have lower risk.
+    rng = np.random.default_rng(seed)
+    candidates = rng.dirichlet(np.ones(n), size=50)
+    optimal_risk = model.estimate(w_opt)
+    for candidate in candidates:
+        assert model.estimate(candidate) >= optimal_risk - 1e-6

--- a/tests/risk/test_reference_solvers.py
+++ b/tests/risk/test_reference_solvers.py
@@ -1,0 +1,258 @@
+"""Cross-solver equivalence tests against independent reference implementations.
+
+The direct Clarabel formulations are checked against solvers with completely
+independent code paths:
+
+- SampleCovariance against scipy's SLSQP on the raw quadratic form.
+- CVar against scipy's HiGHS LP solver on the Rockafellar-Uryasev LP.
+- FactorModel against SampleCovariance on the reconstructed full covariance
+  matrix beta' cov_f beta + diag(idio^2).
+
+Agreement across these pairs would only happen by accident if either side
+built the wrong conic program.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.optimize import LinearConstraint, linprog, minimize
+
+from cvx.core import Variable
+from cvx.risk.cvar import CVar
+from cvx.risk.factor import FactorModel
+from cvx.risk.portfolio import minrisk_problem
+from cvx.risk.sample import SampleCovariance
+
+
+def random_covariance(rng: np.random.Generator, n: int) -> np.ndarray:
+    """Return a random strictly positive definite covariance matrix."""
+    g = rng.standard_normal((n, n))
+    return g.T @ g / n + 0.1 * np.eye(n)
+
+
+def reference_min_volatility(
+    cov: np.ndarray,
+    lower: np.ndarray,
+    upper: np.ndarray,
+    extra: list[tuple[np.ndarray, float | None, float | None]] | None = None,
+) -> float:
+    """Solve the minimum-volatility problem with SLSQP and return the optimal volatility."""
+    n = cov.shape[0]
+    constraints = [LinearConstraint(np.ones(n), 1.0, 1.0)]
+    for a, lb, ub in extra or []:
+        constraints.append(
+            LinearConstraint(a, -np.inf if lb is None else lb, np.inf if ub is None else ub),
+        )
+    result = minimize(
+        lambda w: w @ cov @ w,
+        x0=np.full(n, 1.0 / n),
+        bounds=list(zip(lower, upper, strict=True)),
+        constraints=constraints,
+        method="SLSQP",
+        options={"maxiter": 1000, "ftol": 1e-14},
+    )
+    assert result.success, result.message
+    return float(np.sqrt(result.fun))
+
+
+@pytest.mark.parametrize("seed", range(5))
+@pytest.mark.parametrize("n", [3, 8])
+def test_sample_minrisk_matches_slsqp(seed, n):
+    """The Clarabel SOC solution must match scipy SLSQP on the raw quadratic form."""
+    rng = np.random.default_rng(seed)
+    cov = random_covariance(rng, n)
+    lower = np.zeros(n)
+    upper = rng.uniform(0.5, 1.0, n)
+
+    model = SampleCovariance(num=n)
+    model.update(cov=cov, lower_assets=lower, upper_assets=upper)
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights)
+    problem.solve()
+
+    assert "Solved" in problem.status
+    expected = reference_min_volatility(cov, lower, upper)
+    assert np.isclose(problem.value, expected, rtol=1e-5, atol=1e-7)
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_sample_minrisk_with_extra_constraints_matches_slsqp(seed):
+    """User-supplied linear constraints must be translated into the conic program correctly."""
+    n = 5
+    rng = np.random.default_rng(seed)
+    cov = random_covariance(rng, n)
+    lower = np.zeros(n)
+    upper = np.ones(n)
+    extra = [
+        (np.eye(n)[0], 0.15, None),  # at least 15% in the first asset
+        (rng.uniform(0, 1, n), None, 0.8),  # random exposure capped at 0.8
+        (np.eye(n)[1] - np.eye(n)[2], 0.0, 0.0),  # equal weight in assets 2 and 3
+    ]
+
+    model = SampleCovariance(num=n)
+    model.update(cov=cov, lower_assets=lower, upper_assets=upper)
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights, constraints=extra)
+    problem.solve()
+
+    assert "Solved" in problem.status
+    w = np.array(weights.value)
+    assert w[0] >= 0.15 - 1e-6
+    assert np.isclose(w[1], w[2], atol=1e-6)
+
+    expected = reference_min_volatility(cov, lower, upper, extra=extra)
+    assert np.isclose(problem.value, expected, rtol=1e-5, atol=1e-7)
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_cvar_minrisk_matches_linprog(seed):
+    """The Clarabel CVaR solution must match scipy's HiGHS on the Rockafellar-Uryasev LP."""
+    n_scenarios, m, alpha = 40, 6, 0.9
+    rng = np.random.default_rng(seed)
+    returns = rng.standard_normal((n_scenarios, m)) * 0.02
+
+    model = CVar(alpha=alpha, n=n_scenarios, m=m)
+    model.update(returns=returns, lower_assets=np.zeros(m), upper_assets=np.ones(m))
+    weights = Variable(m)
+    problem = minrisk_problem(model, weights)
+    problem.solve()
+
+    assert "Solved" in problem.status
+
+    # Reference LP over x = [w, gamma, u]: min gamma + sum(u)/k
+    # s.t. -R w - gamma - u <= 0, sum(w) = 1, 0 <= w <= 1, u >= 0.
+    k = model.k
+    c = np.concatenate([np.zeros(m), [1.0], np.full(n_scenarios, 1.0 / k)])
+    a_ub = np.hstack([-returns, -np.ones((n_scenarios, 1)), -np.eye(n_scenarios)])
+    a_eq = np.concatenate([np.ones(m), [0.0], np.zeros(n_scenarios)]).reshape(1, -1)
+    bounds = [(0.0, 1.0)] * m + [(None, None)] + [(0.0, None)] * n_scenarios
+    reference = linprog(c, A_ub=a_ub, b_ub=np.zeros(n_scenarios), A_eq=a_eq, b_eq=[1.0], bounds=bounds)
+    assert reference.success, reference.message
+
+    assert np.isclose(problem.value, reference.fun, rtol=1e-6, atol=1e-8)
+    # The optimal weights must achieve the optimal CVaR (solutions may be non-unique).
+    assert np.isclose(model.estimate(np.array(weights.value)), reference.fun, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("seed", range(3))
+def test_sample_tracking_error_matches_slsqp(seed):
+    """With a base portfolio, the problem must minimize the risk of (w - base)."""
+    n = 5
+    rng = np.random.default_rng(seed)
+    cov = random_covariance(rng, n)
+    base = rng.dirichlet(np.ones(n))
+
+    model = SampleCovariance(num=n)
+    model.update(cov=cov, lower_assets=np.zeros(n), upper_assets=np.ones(n))
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights, base=base)
+    problem.solve()
+    assert "Solved" in problem.status
+
+    constraints = [LinearConstraint(np.ones(n), 1.0, 1.0)]
+    result = minimize(
+        lambda w: (w - base) @ cov @ (w - base),
+        x0=np.full(n, 1.0 / n),
+        bounds=[(0.0, 1.0)] * n,
+        constraints=constraints,
+        method="SLSQP",
+        options={"maxiter": 1000, "ftol": 1e-14},
+    )
+    assert result.success, result.message
+
+    assert np.isclose(problem.value, np.sqrt(result.fun), rtol=1e-5, atol=1e-7)
+
+
+@pytest.mark.parametrize("seed", range(3))
+def test_factor_tracking_error_matches_slsqp(seed):
+    """With a base portfolio, the factor problem must minimize the full tracking error.
+
+    Both the systematic and the idiosyncratic term must be evaluated on the
+    active position (w - base).
+    """
+    n, k = 5, 2
+    rng = np.random.default_rng(seed)
+    cov_f = random_covariance(rng, k)
+    exposure = rng.standard_normal((k, n))
+    idio = rng.uniform(0.05, 0.3, n)
+    base = rng.dirichlet(np.ones(n))
+
+    model = FactorModel(assets=n, k=k)
+    model.update(
+        exposure=exposure,
+        cov=cov_f,
+        idiosyncratic_risk=idio,
+        lower_assets=np.zeros(n),
+        upper_assets=np.ones(n),
+        lower_factors=-100 * np.ones(k),
+        upper_factors=100 * np.ones(k),
+    )
+    weights = Variable(n)
+    problem = minrisk_problem(model, weights, base=base)
+    problem.solve()
+    assert "Solved" in problem.status
+
+    def objective(w):
+        y = exposure @ (w - base)
+        return y @ cov_f @ y + np.sum((idio * (w - base)) ** 2)
+
+    constraints = [LinearConstraint(np.ones(n), 1.0, 1.0)]
+    result = minimize(
+        objective,
+        x0=np.full(n, 1.0 / n),
+        bounds=[(0.0, 1.0)] * n,
+        constraints=constraints,
+        method="SLSQP",
+        options={"maxiter": 1000, "ftol": 1e-14},
+    )
+    assert result.success, result.message
+
+    assert np.isclose(problem.value, np.sqrt(result.fun), rtol=1e-5, atol=1e-7)
+
+
+@pytest.mark.parametrize("seed", range(5))
+@pytest.mark.parametrize("use_base", [False, True])
+def test_factor_minrisk_matches_sample_on_reconstructed_cov(seed, use_base):
+    """With non-binding factor bounds, FactorModel must agree with SampleCovariance.
+
+    The factor model on (exposure, cov_f, idio) and the sample model on the
+    reconstructed covariance beta' cov_f beta + diag(idio^2) describe the same
+    risk, so their minimum-risk problems must have identical optima — with and
+    without a base portfolio.
+    """
+    n, k = 8, 3
+    rng = np.random.default_rng(seed)
+    cov_f = random_covariance(rng, k)
+    exposure = rng.standard_normal((k, n))
+    idio = rng.uniform(0.05, 0.3, n)
+    base = rng.dirichlet(np.ones(n)) if use_base else 0.0
+
+    factor_model = FactorModel(assets=n, k=k)
+    factor_model.update(
+        exposure=exposure,
+        cov=cov_f,
+        idiosyncratic_risk=idio,
+        lower_assets=np.zeros(n),
+        upper_assets=np.ones(n),
+        lower_factors=-100 * np.ones(k),
+        upper_factors=100 * np.ones(k),
+    )
+    w_factor = Variable(n)
+    factor_problem = minrisk_problem(factor_model, w_factor, base=base)
+    factor_problem.solve()
+    assert "Solved" in factor_problem.status
+
+    sample_model = SampleCovariance(num=n)
+    sample_model.update(
+        cov=exposure.T @ cov_f @ exposure + np.diag(idio**2),
+        lower_assets=np.zeros(n),
+        upper_assets=np.ones(n),
+    )
+    w_sample = Variable(n)
+    sample_problem = minrisk_problem(sample_model, w_sample, base=base)
+    sample_problem.solve()
+    assert "Solved" in sample_problem.status
+
+    assert np.isclose(factor_problem.value, sample_problem.value, rtol=1e-6, atol=1e-8)
+    assert np.allclose(np.array(w_factor.value), np.array(w_sample.value), atol=1e-4)

--- a/uv.lock
+++ b/uv.lock
@@ -322,9 +322,12 @@ lint = [
     { name = "pre-commit" },
 ]
 test = [
+    { name = "hypothesis" },
+    { name = "mutmut" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -348,9 +351,12 @@ dev = [
 ]
 lint = [{ name = "pre-commit", specifier = ">=4.0" }]
 test = [
+    { name = "hypothesis", specifier = ">=6.100" },
+    { name = "mutmut", specifier = ">=2.5,<3" },
     { name = "pytest", specifier = ">=9.0" },
     { name = "pytest-cov", specifier = ">=7.0" },
     { name = "pytest-mock", specifier = ">=3.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
 ]
 
 [[package]]
@@ -381,12 +387,30 @@ wheels = [
 ]
 
 [[package]]
+name = "glob2"
+version = "0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/a5/bbbc3b74a94fbdbd7915e7ad030f16539bfdc1362f7e9003b594f0537950/glob2-0.7.tar.gz", hash = "sha256:85c3dbd07c8aa26d63d7aacee34fa86e9a91a3873bc30bf62ec46e531f92ab8c", size = 10697, upload-time = "2019-06-10T23:33:48.308Z" }
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.155.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/04/64032a1dccd2233615c8a3f701bbb563558575ed017496a24b6d81762c91/hypothesis-6.155.2.tar.gz", hash = "sha256:ae36880287c9c5defe9f199d3d2b67d9947a4da2a46e6c57373cbdf2345b20e1", size = 477765, upload-time = "2026-06-05T16:32:23.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/6e/e735f27ac1a530a4cd0a31cd970ec495a3a11830fdc5d281cc292593b330/hypothesis-6.155.2-py3-none-any.whl", hash = "sha256:c85ce6dcd630a90ce501f1d1dd1bc84b97f5649ca8a27e134c8cbf5aa480b1a5", size = 544213, upload-time = "2026-06-05T16:32:21.15Z" },
 ]
 
 [[package]]
@@ -464,6 +488,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/7b/03fe36a491784f8ae32ef1d18a13827200894ba9e2462ccf390d4fe0bde8/jquantstats-0.9.2.tar.gz", hash = "sha256:b6116c2dcb9f3819ff3dda1b81ec011d0406df5ef075cae1b9b3acaaf70e2232", size = 97241, upload-time = "2026-05-24T08:39:14.959Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/71/7ff0e04c0d2a5309c11b6c9d077cd90819818dc1ae248c3234f1dd712965/jquantstats-0.9.2-py3-none-any.whl", hash = "sha256:2c6d9ec68fbe755527c33434ffa7471c6ed72767182d5acf1186e0a6f4be278c", size = 112663, upload-time = "2026-05-24T08:39:13.44Z" },
+]
+
+[[package]]
+name = "junit-xml"
+version = "1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/af/bc988c914dd1ea2bc7540ecc6a0265c2b6faccc6d9cdb82f20e2094a8229/junit-xml-1.9.tar.gz", hash = "sha256:de16a051990d4e25a3982b2dd9e89d671067548718866416faec14d9de56db9f", size = 7349, upload-time = "2023-01-24T18:42:00.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/93/2d896b5fd3d79b4cadd8882c06650e66d003f465c9d12c488d92853dff78/junit_xml-1.9-py2.py3-none-any.whl", hash = "sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732", size = 7130, upload-time = "2020-02-22T20:41:37.661Z" },
 ]
 
 [[package]]
@@ -718,6 +754,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mutmut"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "glob2" },
+    { name = "junit-xml" },
+    { name = "parso" },
+    { name = "pony" },
+    { name = "toml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/b3/bbeef9223c0f25b7336e673723f667e3a851dbe7ad235c9180937739dd44/mutmut-2.5.1.tar.gz", hash = "sha256:d8fea2538805277f6290922e88881ad045002fc284d5a53c2b3915298b77f79d", size = 50502, upload-time = "2024-08-15T13:55:23.418Z" }
+
+[[package]]
 name = "narwhals"
 version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -892,6 +942,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pony"
+version = "0.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/59/ab6542afa95de0d5a16545ce6ce683960352cfd9a2318722593b81a98123/pony-0.7.19.tar.gz", hash = "sha256:f7f83b2981893e49f7f18e8def52ad8fa8f8e6c5f9583b9aaed62d4d85036a0f", size = 258589, upload-time = "2024-08-27T12:29:29.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/cb/0ef8429024309fe6f5edf1debc7cf63adeaeb34b2242490cc18710658abd/pony-0.7.19-py3-none-any.whl", hash = "sha256:5112b4cf40d3f24e93ae66dc5ab7dc6813388efa870e750928d60dc699873cf5", size = 317259, upload-time = "2024-08-27T12:29:28.247Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1028,6 +1087,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]
@@ -1285,6 +1356,24 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "sparsediffpy"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1326,6 +1415,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Bug fix**: `FactorModel.solve_minrisk` applied the base portfolio only to the idiosyncratic term. The systematic term now uses `exposure @ (w - base)`, so tracking-error minimization covers the full active position. Found via mutation testing, which showed the base-portfolio sign terms were numerically unverified.
- **Refactor**: the three duplicated `solve_minrisk` implementations (~260 lines of shared Clarabel boilerplate) are extracted into a shared `ConeProgramBuilder` (`cvx.core.conic`). Each model now contains only its model-specific math.
- **Performance**: constraint blocks are assembled sparsely; factor and CVaR build their large structured blocks directly in sparse form. Measured: factor n=5000 0.82s → 0.22s, CVaR T=8000 1.69s → 0.78s, identical optima.
- **API hardening**: `update()` / `solve_minrisk()` validate inputs with actionable `ValueError`s (missing keys, typo'd bound names, shape mismatches, capacity overflows). The no-raise failure contract of `MinRiskProblem.solve()` is documented explicitly.
- **Testing**: 28 → 133 tests. Hypothesis property tests, reference-solver equivalence vs scipy SLSQP/HiGHS and cvxpy, failure-path and API-contract tests, doctests in every pytest run. The previously broken `make mutation` target now works (pinned mutmut 2.x + runner config); final run kills ~87% of mutants with all survivors triaged as equivalent or cosmetic.
- **Housekeeping**: license aligned to MIT everywhere (source headers, README badge/section) to match `LICENSE` and `pyproject.toml`; new `docs/models.md` documents the exact conic program per model; root `CONTRIBUTING.md` added; README install section no longer advertises the paused PyPI release.

## Test plan

- [x] `pytest` — 133 passed (unit + property + reference-equivalence + doctests)
- [x] `pytest` with benchmark group — 147 passed incl. cvxpy equivalence and benchmarks
- [x] `ty check src`, `ruff check`, `ruff format`, full pre-commit — clean
- [x] Mutation testing (`make mutation`) — survivors triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)