### PR TITLE
feat: add ClusterFuzzLite fuzzing scaffold for cvxrisk

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,9 @@
+# ClusterFuzzLite build image for cvxrisk.
+# Uses the OSS-Fuzz Python base image, which provides Atheris and the
+# compile_python_fuzzer helper.
+# Pinned by SHA256 so the build image only changes through reviewed updates.
+FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
+
+COPY . $SRC
+WORKDIR $SRC
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script — installs cvxrisk and compiles each Python
+# harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
+
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
+
+# Install the package and its runtime dependencies (numpy, scipy, clarabel,
+# cvx-linalg) so PyInstaller can discover and bundle cvxrisk into each frozen
+# fuzzer binary.
+pip3 install .
+
+# PyInstaller does not discover the compiled extension modules of numpy/scipy on
+# their own, so the frozen fuzzer crashes at runtime (numpy: "No module named
+# 'numpy._core._exceptions'"; scipy: "No module named 'scipy._cyutility'").
+# --collect-all pulls in every submodule, data file and shared library for both.
+# clarabel (a single Rust extension) is bundled via the static import graph.
+for fuzzer in tests/fuzz/fuzz_*.py; do
+  compile_python_fuzzer "$fuzzer" --collect-all numpy --collect-all scipy
+done

--- a/tests/fuzz/conftest.py
+++ b/tests/fuzz/conftest.py
@@ -1,0 +1,12 @@
+"""Keep the Atheris fuzz harnesses out of the normal pytest run.
+
+The ``fuzz_*.py`` modules import ``atheris`` and are meant to be compiled and
+driven by ClusterFuzzLite, not collected by pytest. The project enables
+``--doctest-modules``, which would otherwise import every module here looking
+for doctests and fail with ``ModuleNotFoundError: No module named 'atheris'``
+in environments where the fuzzing extras are not installed.
+"""
+
+from __future__ import annotations
+
+collect_ignore_glob = ["fuzz_*.py"]

--- a/tests/fuzz/fuzz_sample_risk.py
+++ b/tests/fuzz/fuzz_sample_risk.py
@@ -1,0 +1,59 @@
+"""Fuzz the cvxrisk sample-covariance risk model against arbitrary matrices.
+
+``SampleCovariance`` ingests a covariance matrix via ``update`` and computes the
+portfolio risk (``||R @ w||``) via ``estimate``. Neither should crash with an
+unexpected exception on adversarial input — degenerate, non-finite or
+non-positive-definite covariance matrices should produce a result or raise a
+documented error (cvx.linalg raises ValueError/TypeError subclasses; numpy may
+raise ``LinAlgError``). This harness exercises that contract with coverage-guided
+input.
+
+Run locally:
+    pip install atheris numpy scipy clarabel cvx-linalg
+    python tests/fuzz/fuzz_sample_risk.py -atheris_runs=20000
+
+Run in ClusterFuzzLite: this file is built by .clusterfuzzlite/build.sh.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+
+import atheris
+
+# Pre-import the heavy native dependencies OUTSIDE the instrumentation block.
+# Atheris's import hook miscompiles parts of Rust/C extensions' Python machinery
+# (e.g. clarabel), so we let them load uninstrumented and instrument only the
+# first-party package under test.
+import clarabel  # noqa: F401  # pre-imported uninstrumented
+import numpy as np
+import scipy.sparse  # noqa: F401  # pre-imported uninstrumented
+
+with atheris.instrument_imports():
+    from cvx.risk.sample import SampleCovariance
+
+_ALLOWED = (ValueError, TypeError, np.linalg.LinAlgError)
+
+
+def test_one_input(data: bytes) -> None:
+    """Build, update and estimate a SampleCovariance model from fuzzed data."""
+    fdp = atheris.FuzzedDataProvider(data)
+    n = fdp.ConsumeIntInRange(1, 5)
+    cov = np.array([fdp.ConsumeFloat() for _ in range(n * n)], dtype=np.float64).reshape(n, n)
+    weights = np.array([fdp.ConsumeFloat() for _ in range(n)], dtype=np.float64)
+
+    model = SampleCovariance(num=n)
+    with contextlib.suppress(_ALLOWED):
+        model.update(cov=cov, lower_assets=np.zeros(n), upper_assets=np.ones(n))
+        model.estimate(weights)
+
+
+def main() -> None:
+    """Run the Atheris fuzz loop."""
+    atheris.Setup(sys.argv, test_one_input)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the opt-in **ClusterFuzzLite** fuzzing scaffold so the existing `rhiza_fuzzing.yml` workflow actually runs.

- `.clusterfuzzlite/Dockerfile` — OSS-Fuzz Python base image, SHA-pinned
- `.clusterfuzzlite/build.sh` — installs `cvxrisk` and compiles each `tests/fuzz/fuzz_*.py` harness; `--collect-all numpy --collect-all scipy` bundles their compiled extensions (clarabel bundles via the import graph)
- `tests/fuzz/fuzz_sample_risk.py` — Atheris harness fuzzing `SampleCovariance` (`update` + `estimate`) with arbitrary covariance matrices/weights, treating only documented `ValueError`/`TypeError`/`LinAlgError` as acceptable. Native deps pre-imported outside `instrument_imports()`.

`FUZZING_ENABLED` is already set to `true`.

## Test plan
- [x] Built **and run** locally against the OSS-Fuzz `base-builder-python` image — 1500 runs, no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
