### PR TITLE
test(risk): cover the two untested input-validation guard branches (#489)

### DIFF
--- a/tests/risk/test_failure_paths.py
+++ b/tests/risk/test_failure_paths.py
@@ -150,10 +150,17 @@ def test_update_validation_messages():
     cvar = CVar(alpha=0.9, n=10, m=3)
     with pytest.raises(ValueError, match="requires a 'returns'"):
         cvar.update(lower_assets=np.zeros(3), upper_assets=np.ones(3))
+    with pytest.raises(ValueError, match="2d matrix"):
+        cvar.update(returns=np.zeros((10,)), lower_assets=np.zeros(3), upper_assets=np.ones(3))
     with pytest.raises(ValueError, match=r"expects n=10"):
         cvar.update(returns=np.zeros((5, 3)), lower_assets=np.zeros(3), upper_assets=np.ones(3))
     with pytest.raises(ValueError, match="Too many assets"):
         cvar.update(returns=np.zeros((10, 4)), lower_assets=np.zeros(4), upper_assets=np.ones(4))
+
+    # Bounds.update() length guard: an over-length bound array (length 4 > m=3)
+    # reaches Bounds.update() via CVar.update() and must be rejected.
+    with pytest.raises(ValueError, match="maximum is"):
+        cvar.update(returns=np.zeros((10, 3)), lower_assets=np.zeros(4), upper_assets=np.ones(3))
 
 
 def test_solve_minrisk_dimension_mismatch():


### PR DESCRIPTION
Closes #489

## Summary
Cover the two previously-untested input-validation `ValueError` guard branches in `src/`, raising src coverage from 98.98% to **100%**. Test-only change — no `src/` behavior modified.

Both guards are reachable and now exercised via additions to `tests/risk/test_failure_paths.py::test_update_validation_messages`:

- **`src/cvx/risk/cvar/cvar.py:229-231`** — `CVar.update()` dimensionality guard. New assertion passes a 1-D `returns=np.zeros((10,))` and asserts `pytest.raises(ValueError, match="2d matrix")`.
- **`src/cvx/core/bounds.py:175-177`** — `Bounds.update()` length guard. New assertion passes an over-length `lower_assets=np.zeros(4)` (with `m=3`), which reaches `Bounds.update()` through `CVar.update()`, asserting `pytest.raises(ValueError, match="maximum is")`.

## Coverage
- Before: 98.98% (4 missing statements: `bounds.py` 176-177, `cvar.py` 230-231)
- After: **100.00%** — `src/cvx/core/bounds.py` and `src/cvx/risk/cvar/cvar.py` both at 100%, 0 missing project-wide.

## Gates
- `make test` — PASS (133 passed, 100.00% coverage)
- `make fmt` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
