### PR TITLE
fix(cvar): reject degenerate empty-tail CVar (k == 0)

### DIFF
--- a/src/cvx/risk/cvar/cvar.py
+++ b/src/cvx/risk/cvar/cvar.py
@@ -138,6 +138,20 @@ class CVar(Model):
         Calculates the number of samples in the tail (k) based on alpha,
         creates the returns parameter matrix, and initializes the bounds.
 
+        The tail size is ``k = floor(n * (1 - alpha))``, computed with a small
+        rounding tolerance so that exact fractions such as ``n=10, alpha=0.9``
+        yield ``k=1`` rather than ``0`` (``1 - 0.9`` is slightly below ``0.1``
+        in floating point, which would otherwise truncate down to ``0``).
+
+        Raises:
+            ValueError: If a configured model (``n > 0``) yields an empty tail
+                (``k == 0``) — e.g. ``alpha=0.99`` with ``n=50``. An empty tail
+                makes the risk undefined (``estimate`` returns ``nan`` and the
+                solver objective divides by zero), so the degenerate model is
+                rejected up front. Increase ``n`` or lower ``alpha``. The
+                all-defaults placeholder ``CVar()`` (``n == 0``) is left
+                constructible, mirroring the other risk models.
+
         Example:
             >>> from cvx.risk.cvar import CVar
             >>> model = CVar(alpha=0.95, n=100, m=5)
@@ -148,8 +162,23 @@ class CVar(Model):
             >>> model.parameter["R"].shape
             (100, 5)
 
+            An exact fraction is not truncated by floating-point error:
+
+            >>> CVar(alpha=0.9, n=10, m=3).k
+            1
+
+            A configured alpha/n combination with an empty tail is rejected:
+
+            >>> CVar(alpha=0.99, n=50, m=3)
+            Traceback (most recent call last):
+                ...
+            ValueError: alpha=0.99 with n=50 yields an empty CVaR tail (k=0); increase n or lower alpha
+
         """
-        self.k = int(self.n * (1 - self.alpha))
+        self.k = int(np.floor(round(self.n * (1 - self.alpha), 9)))
+        if self.n > 0 and self.k < 1:
+            msg = f"alpha={self.alpha} with n={self.n} yields an empty CVaR tail (k=0); increase n or lower alpha"
+            raise ValueError(msg)
         self.parameter["R"] = Parameter(shape=(self.n, self.m), name="returns")
         self.bounds = Bounds(m=self.m, name="assets")
 

--- a/tests/risk/test_failure_paths.py
+++ b/tests/risk/test_failure_paths.py
@@ -202,6 +202,17 @@ def test_solve_minrisk_dimension_mismatch():
         problem.solve()
 
 
+def test_cvar_empty_tail_rejected():
+    """An alpha/n combination with an empty tail (k == 0) must be rejected at construction.
+
+    With ``k = int(n * (1 - alpha)) == 0`` the tail average is undefined:
+    ``estimate`` would return ``nan`` and ``solve_minrisk`` would divide by zero.
+    Rejecting it up front turns a cryptic downstream failure into a clear error.
+    """
+    with pytest.raises(ValueError, match=r"alpha=0.99 with n=50 yields an empty CVaR tail \(k=0\)"):
+        CVar(alpha=0.99, n=50, m=3)
+
+
 def test_resolve_after_infeasible_recovers():
     """After an infeasible solve, fixing the bounds and re-solving must succeed."""
     n = 3

--- a/tests/risk/test_properties.py
+++ b/tests/risk/test_properties.py
@@ -94,7 +94,10 @@ def test_cvar_estimate_is_tail_mean(data):
     model = CVar(alpha=alpha, n=n_scenarios, m=m_max)
     model.update(returns=returns, lower_assets=np.zeros(m_used), upper_assets=np.ones(m_used))
 
-    k = int(n_scenarios * (1 - alpha))
+    # Use the model's own tail size: it is floor(n*(1-alpha)) computed with a
+    # rounding tolerance, so exact fractions (e.g. n=20, alpha=0.8 -> 4) are not
+    # truncated by floating-point error the way a naive int(n*(1-alpha)) would be.
+    k = model.k
     padded_w = np.zeros(m_max)
     padded_w[:m_used] = w
     expected = -np.mean(np.sort(returns @ w)[:k])


### PR DESCRIPTION
Closes #492

## Problem

`CVar.__post_init__` set the tail size as `self.k = int(self.n * (1 - self.alpha))`. Two latent bugs followed:

1. **Empty tail (`k == 0`).** For high `alpha` / small `n` — e.g. `CVar(alpha=0.99, n=50)` → `k = int(0.5) = 0` — the model is unusable:
   - `estimate()` does `np.mean(sorted_returns[:0])` → returns **`nan`** with a silent `RuntimeWarning: Mean of empty slice`.
   - `solve_minrisk()` does `q[u_cols] = 1.0 / k` → raises an opaque **`ZeroDivisionError: float division by zero`**, violating the documented "check `status`" failure contract.

2. **Floating-point truncation.** `int(n * (1 - alpha))` truncates after FP error: `10 * (1 - 0.9) = 0.9999…` → `k = 0`, even though the mathematically-correct tail is `1`. So `CVar(alpha=0.9, n=10)` was silently degenerate.

## Fix

- `k = int(np.floor(round(n * (1 - alpha), 9)))` — robust to FP error. Documented values (5, 2, 1, 25, …) are unchanged; `alpha=0.9, n=10` now correctly gives `k=1`.
- Raise a clear `ValueError` (naming `alpha`/`n`/`k`) for a **configured** model (`n > 0`) that still yields `k == 0`. The all-defaults placeholder `CVar()` (`n == 0`) stays constructible, matching `SampleCovariance()` / `FactorModel()` and the existing `test_constructor_defaults` contract.
- `test_cvar_estimate_is_tail_mean` now reads `model.k` instead of recomputing the (stale, truncating) tail size.

## Tests / gates

- New regression test `test_cvar_empty_tail_rejected` in `tests/risk/test_failure_paths.py`.
- New doctests on `__post_init__` (FP fix + rejection).
- `make fmt`, `make typecheck` (ty + mypy strict), `make docs-coverage` (100%), `make test` (134 passed, 100% coverage) all green.

_From rhiza_quality re-assessment (round 2)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)