### PR TITLE
chore: update rhiza to v1.0.0

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.0.0
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.0.0
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_release.yml
+++ b/.github/workflows/rhiza_release.yml
@@ -221,7 +221,7 @@ jobs:
           version: "0.11.16"
 
       - name: Configure git auth for private packages
-        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v0.19.9
+        uses: jebel-quant/rhiza/.github/actions/configure-git-auth@v1.0.0
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.0.0
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v1.0.0
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.19.9
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.0.0
     secrets: inherit

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: ff7bd135efaaad8aadf01d41bb60dd8419c015ae
+sha: 3186f09ecffa95a44148fbae02bc90d9e9dd05e2
 repo: jebel-quant/rhiza
 host: github
-ref: v0.19.9
+ref: v1.0.0
 include: []
 exclude: []
 templates:
@@ -107,5 +107,5 @@ files:
 - ruff.toml
 profiles:
 - github-project
-synced_at: '2026-06-28T13:14:39Z'
+synced_at: '2026-06-29T09:52:37Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 template-repository: "jebel-quant/rhiza"
-template-branch: "v0.19.9"
+template-branch: "v1.0.0"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary
- Bumps the template `template-branch` to `v1.0.0` in `.rhiza/template.yml` (major bump from `v0.19.9`, confirmed by maintainer)
- Platform profile: `github-project` (unchanged — matches the GitHub origin)
- Runs `make sync` to apply upstream template changes; merge applied cleanly with **no conflicts** and no `.rej` files
- `.rhiza/.rhiza-version` left untouched (decoupled rhiza-cli tool version, still `0.18.0`)

## Quality gates

| Gate | Result |
|------|--------|
| `make fmt` (ruff, markdownlint, bandit hook, actionlint, secrets) | ✅ PASS |
| `make typecheck` (ty + mypy --strict over src/) | ✅ PASS — no issues, 19 files |
| `make docs-coverage` (interrogate over src/) | ✅ PASS — 100.0% (min 100.0%) |
| `make deptry` (dependency hygiene) | ✅ PASS — no issues, 15 files |
| `make security` (pip-audit + bandit) | ✅ PASS — no vulnerabilities |
| `make validate` (template structure + .rhiza infra suite) | ✅ PASS — 173 passed, 2 skipped |
| `make test` (project suite + coverage gate) | ✅ PASS — 134 passed, 100% coverage (min 90%) |

**All gates PASS.**

## Scorecard

Scoped to locally-owned items (`src/`, `tests/`, `pyproject.toml`, `README.md`, `.rhiza/template.yml`). Rhiza-managed infra (`.github/workflows/*`, `Makefile`, `pytest.ini`, `ruff.toml`, pre-commit config) is upstream/out-of-scope.

| Subcategory | Score | Justification |
|-------------|-------|---------------|
| Linting & style | 10/10 | `make fmt` fully green; ruff format + check clean. |
| Type safety | 10/10 | `ty` + `mypy --strict` clean across 19 source files. |
| Test pass rate | 10/10 | 134/134 project tests pass; 0 failures. |
| Test coverage & depth | 10/10 | 100% line coverage on `src/` (gate 90%); suite spans properties, fuzz, cvxpy-equivalence, reference-solver, contract, integration tests. |
| Documentation (docstrings) | 10/10 | interrogate 100% over `src/`. |
| Dependency & security hygiene | 10/10 | deptry clean; pip-audit no vulns; bandit clean. |
| Code structure & readability | 9/10 | Lint/type-clean and well-factored (core/risk split), but readability is only gate-verified to the extent lint/types cover it — not a deep line-by-line review. |
| CI / tooling health | n/a | Rhiza-owned (`.github/workflows/*`, Makefile) — upstream/out-of-scope. |

**Overall: 9.9/10** — repo is in excellent shape; the v1.0.0 sync applied cleanly with every gate passing.

**Highest-leverage improvement:** None blocking. The only sub-10 is the subjective code-structure mark, which is not gate-backed; a one-pass readability review of `src/cvx/risk/` would confirm or close it.

## Recommendations
- Nothing actionable from the gates — all measurable categories are maxed.
- Optional: a manual readability pass over `src/cvx/risk/` to lift code-structure 9→10.
