### PR TITLE
refactor(risk): reduce update complexity and unify solve_minrisk tail (#500, #501)

### DIFF
--- a/src/cvx/core/model.py
+++ b/src/cvx/core/model.py
@@ -28,12 +28,17 @@ Example:
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
 from cvx.core.parameter import Parameter
+
+if TYPE_CHECKING:
+    from cvx.core.conic import ConeProgramBuilder
+    from cvx.core.variable import Variable
 
 
 @dataclass
@@ -121,3 +126,48 @@ class Model(ABC):
             ... )
 
         """
+
+    def _solve_and_unpack(
+        self,
+        builder: ConeProgramBuilder,
+        q: np.ndarray,
+        weights: Variable,
+        w_cols: slice,
+        result: Callable[[Any], tuple[float, float]],
+        *,
+        y_var: Variable | None = None,
+        y_cols: slice | None = None,
+    ) -> tuple[float | None, float | None, str]:
+        """Solve an assembled cone program and unpack the primal solution.
+
+        This is the shared tail of every concrete :meth:`solve_minrisk`: it runs
+        the Clarabel solver on the linear objective ``q`` and, on a solved
+        status, copies the optimal asset weights (and, when both ``y_var`` and
+        ``y_cols`` are supplied, the factor exposures) back into the caller's
+        variables. The reported ``(objective, risk)`` pair is derived from the
+        solution by the model-specific ``result`` callback. If the solver does
+        not converge, returns ``(None, None, status)`` and leaves the variables
+        untouched.
+
+        Args:
+            builder: The cone program with all constraints already added.
+            q: Linear objective coefficients.
+            weights: Variable that receives the optimal asset weights.
+            w_cols: Columns of the solution vector holding the asset weights.
+            result: Maps the solved solution to the ``(objective, risk)`` pair.
+            y_var: Optional variable that receives the optimal factor exposures.
+            y_cols: Columns of the solution vector holding the factor exposures.
+
+        Returns:
+            ``(objective, risk, status)`` on a solved status, otherwise
+            ``(None, None, status)``.
+
+        """
+        sol, status = builder.solve(q)
+        if "Solved" not in status:
+            return None, None, status
+        weights.value = np.array(sol.x[w_cols])
+        if y_var is not None and y_cols is not None:
+            y_var.value = np.array(sol.x[y_cols])
+        objective, risk = result(sol)
+        return objective, risk, status

--- a/src/cvx/risk/cvar/cvar.py
+++ b/src/cvx/risk/cvar/cvar.py
@@ -327,6 +327,7 @@ class CVar(Model):
         q[u_cols] = 1.0 / k
 
         def result(sol: Any) -> tuple[float, float]:
+            """Return the CVaR objective value as both the risk and the reported minimum."""
             cvar_val = float(q @ sol.x)
             return cvar_val, cvar_val
 

--- a/src/cvx/risk/cvar/cvar.py
+++ b/src/cvx/risk/cvar/cvar.py
@@ -325,10 +325,9 @@ class CVar(Model):
         q = np.zeros(builder.n_vars)
         q[gamma_col] = 1.0
         q[u_cols] = 1.0 / k
-        sol, status = builder.solve(q)
 
-        if "Solved" in status:
-            weights.value = np.array(sol.x[w_cols])
+        def result(sol: Any) -> tuple[float, float]:
             cvar_val = float(q @ sol.x)
-            return cvar_val, cvar_val, status
-        return None, None, status
+            return cvar_val, cvar_val
+
+        return self._solve_and_unpack(builder, q, weights, w_cols, result)

--- a/src/cvx/risk/factor/factor.py
+++ b/src/cvx/risk/factor/factor.py
@@ -232,6 +232,58 @@ class FactorModel(Model):
 
         return float(np.sqrt(var_systematic**2 + var_residual**2))
 
+    @staticmethod
+    def _require_inputs(kwargs: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return the ``exposure``, ``cov`` and ``idiosyncratic_risk`` arrays from ``kwargs``.
+
+        Raises:
+            ValueError: If any of the three required arguments is missing.
+
+        """
+        missing = [key for key in ("exposure", "cov", "idiosyncratic_risk") if key not in kwargs]
+        if missing:
+            msg = f"update() missing required arguments: {', '.join(missing)}"
+            raise ValueError(msg)
+        return (
+            np.asarray(kwargs["exposure"]),
+            np.asarray(kwargs["cov"]),
+            np.asarray(kwargs["idiosyncratic_risk"]),
+        )
+
+    def _validate_shapes(
+        self,
+        exposure: np.ndarray,
+        cov: np.ndarray,
+        idiosyncratic_risk: np.ndarray,
+    ) -> tuple[int, int]:
+        """Check the input shapes against the model capacity and each other.
+
+        Returns:
+            The active ``(num_factors, num_assets)`` read from ``exposure``.
+
+        Raises:
+            ValueError: If the number of factors or assets exceeds the model
+                capacity, or ``cov``/``idiosyncratic_risk`` are inconsistent
+                with ``exposure``.
+
+        """
+        num_factors, num_assets = exposure.shape
+        if num_factors > self.k:
+            msg = "Too many factors"
+            raise ValueError(msg)
+        if num_assets > self.assets:
+            msg = "Too many assets"
+            raise ValueError(msg)
+        if cov.shape != (num_factors, num_factors):
+            msg = f"cov must have shape ({num_factors}, {num_factors}) to match exposure, got {cov.shape}"
+            raise ValueError(msg)
+        if idiosyncratic_risk.shape != (num_assets,):
+            msg = (
+                f"idiosyncratic_risk must have shape ({num_assets},) to match exposure, got {idiosyncratic_risk.shape}"
+            )
+            raise ValueError(msg)
+        return num_factors, num_assets
+
     def update(self, **kwargs: Any) -> None:
         """Update the factor model parameters.
 
@@ -271,31 +323,8 @@ class FactorModel(Model):
             ... )
 
         """
-        missing = [key for key in ("exposure", "cov", "idiosyncratic_risk") if key not in kwargs]
-        if missing:
-            msg = f"update() missing required arguments: {', '.join(missing)}"
-            raise ValueError(msg)
-
-        exposure = np.asarray(kwargs["exposure"])
-        cov = np.asarray(kwargs["cov"])
-        idiosyncratic_risk = np.asarray(kwargs["idiosyncratic_risk"])
-
-        # Extract the active factor/asset dimensions from the input exposure matrix.
-        num_factors, num_assets = exposure.shape
-        if num_factors > self.k:
-            msg = "Too many factors"
-            raise ValueError(msg)
-        if num_assets > self.assets:
-            msg = "Too many assets"
-            raise ValueError(msg)
-        if cov.shape != (num_factors, num_factors):
-            msg = f"cov must have shape ({num_factors}, {num_factors}) to match exposure, got {cov.shape}"
-            raise ValueError(msg)
-        if idiosyncratic_risk.shape != (num_assets,):
-            msg = (
-                f"idiosyncratic_risk must have shape ({num_assets},) to match exposure, got {idiosyncratic_risk.shape}"
-            )
-            raise ValueError(msg)
+        exposure, cov, idiosyncratic_risk = self._require_inputs(kwargs)
+        num_factors, num_assets = self._validate_shapes(exposure, cov, idiosyncratic_risk)
 
         self.parameter["exposure"].value = np.zeros((self.k, self.assets))
         self.parameter["chol"].value = np.zeros((self.k, self.k))
@@ -371,11 +400,12 @@ class FactorModel(Model):
 
         q = np.zeros(builder.n_vars)
         q[0] = 1.0
-        sol, status = builder.solve(q)
-
-        if "Solved" in status:
-            weights.value = np.array(sol.x[w_cols])
-            if y_var is not None:
-                y_var.value = np.array(sol.x[y_cols])
-            return float(sol.obj_val), float(sol.x[0]), status
-        return None, None, status
+        return self._solve_and_unpack(
+            builder,
+            q,
+            weights,
+            w_cols,
+            lambda sol: (float(sol.obj_val), float(sol.x[0])),
+            y_var=y_var,
+            y_cols=y_cols,
+        )

--- a/src/cvx/risk/sample/sample.py
+++ b/src/cvx/risk/sample/sample.py
@@ -254,9 +254,10 @@ class SampleCovariance(Model):
 
         q = np.zeros(builder.n_vars)
         q[0] = 1.0
-        sol, status = builder.solve(q)
-
-        if "Solved" in status:
-            weights.value = np.array(sol.x[w_cols])
-            return float(sol.obj_val), float(sol.x[0]), status
-        return None, None, status
+        return self._solve_and_unpack(
+            builder,
+            q,
+            weights,
+            w_cols,
+            lambda sol: (float(sol.obj_val), float(sol.x[0])),
+        )


### PR DESCRIPTION
Addresses #500 and #501, both surfaced by the `/global_rhiza_quality` assessment.

## #500 — Reduce cyclomatic complexity of `FactorModel.update`

`FactorModel.update` was the most complex block in the codebase (radon **B(8)**). Its argument handling is extracted into two named helpers so the method body reads as a sequence of intent-level steps:

- `_require_inputs(kwargs)` — pull out `exposure`/`cov`/`idiosyncratic_risk`, raising on missing keys.
- `_validate_shapes(...)` — check model capacity and cross-consistency, return the active `(num_factors, num_assets)`.

`FactorModel.update` now ranks **A(1)**; no C-or-worse blocks remain and the `radon cc src -a` average improved (2.26 → 2.16).

## #501 — Unify duplicated `solve_minrisk` scaffolding

The three concrete models each re-implemented the same solve-and-unpack tail. That scaffolding is hoisted into a base-class template method `Model._solve_and_unpack`:

> run the solver on `q` → if not solved, return `(None, None, status)` → else copy the optimal weights (and optional factor exposures via `y_var`/`y_cols`) back into the caller's variables and return `(objective, risk, status)`.

Each model now supplies only what genuinely differs: its constraint assembly, objective vector `q`, and a small `result(sol)` callback for the `(objective, risk)` pair. **No numeric behavior change** — each model keeps its exact objective/risk expression.

`estimate`/`update` are intentionally left per-model: their bodies differ in substance (different math; per-model validation messages; factor writes 3 parameters and updates 2 bounds objects), so templating them would force artificial abstraction rather than remove real duplication.

## Verification

- `make test` — 94 passed, 100% coverage.
- doctests — 40 passed.
- `ruff check` and the type checker clean.
- `radon cc src -a` average 2.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)