### PR TITLE
refactor(core): lower add_linear_constraints complexity (#513)

### DIFF
--- a/src/cvx/core/conic.py
+++ b/src/cvx/core/conic.py
@@ -126,6 +126,38 @@ class ConeProgramBuilder:
         self.add(sparse.hstack([left, -eye, right]), -lower, clarabel.NonnegativeConeT(m))
         self.add(sparse.hstack([left, eye, right]), upper, clarabel.NonnegativeConeT(m))
 
+    def _add_scalar_row(self, a: np.ndarray, cols: slice, rhs: float, cone: Any) -> None:
+        """Add a single-row constraint ``a @ x[cols] + s = rhs`` with ``s`` in ``cone``.
+
+        Args:
+            a: Coefficient vector for the selected columns.
+            cols: Column slice the coefficients refer to.
+            rhs: Scalar right-hand side.
+            cone: Clarabel cone for the row's slack.
+
+        """
+        row = self.block(1)
+        row[0, cols] = a
+        self.add(row, np.array([rhs]), cone)
+
+    def _add_inequalities(self, a: np.ndarray, cols: slice, lower: float | None, upper: float | None) -> None:
+        """Add the one-sided rows for ``lower <= a @ x[cols] <= ub``.
+
+        Each present bound becomes a ``NonnegativeConeT`` row; ``None`` sides
+        are skipped.
+
+        Args:
+            a: Coefficient vector for the selected columns.
+            cols: Column slice the coefficients refer to.
+            lower: Lower bound, or ``None`` to leave the expression unbounded below.
+            upper: Upper bound, or ``None`` to leave the expression unbounded above.
+
+        """
+        if lower is not None:
+            self._add_scalar_row(-a, cols, -lower, clarabel.NonnegativeConeT(1))
+        if upper is not None:
+            self._add_scalar_row(a, cols, upper, clarabel.NonnegativeConeT(1))
+
     def add_linear_constraints(self, constraints: list[LinearConstraint], cols: slice) -> None:
         """Add user-supplied linear constraints ``lb <= a @ x[cols] <= ub``.
 
@@ -139,18 +171,9 @@ class ConeProgramBuilder:
         for coeffs, lower, upper in constraints:
             a = np.asarray(coeffs)
             if lower is not None and upper is not None and lower == upper:
-                row = self.block(1)
-                row[0, cols] = a
-                self.add(row, np.array([lower]), clarabel.ZeroConeT(1))
-                continue
-            if lower is not None:
-                row = self.block(1)
-                row[0, cols] = -a
-                self.add(row, np.array([-lower]), clarabel.NonnegativeConeT(1))
-            if upper is not None:
-                row = self.block(1)
-                row[0, cols] = a
-                self.add(row, np.array([upper]), clarabel.NonnegativeConeT(1))
+                self._add_scalar_row(a, cols, lower, clarabel.ZeroConeT(1))
+            else:
+                self._add_inequalities(a, cols, lower, upper)
 
     def solve(self, q: np.ndarray) -> tuple[Any, str]:
         """Assemble the accumulated blocks, solve with Clarabel, and return the result.


### PR DESCRIPTION
## Summary
Closes #513 — the sole below-10 finding from the rhiza v1.1.2 quality scorecard (#512).

`ConeProgramBuilder.add_linear_constraints` ranked radon **B (CC 7)** — the only non-A block in `src/`. Extracted two private helpers:
- `_add_scalar_row(a, cols, rhs, cone)` — builds and adds a single-row block
- `_add_inequalities(a, cols, lower, upper)` — emits the one-sided `NonnegativeConeT` rows

The equality check stays inline so mypy narrows the bounds to `float`.

## Result
- `add_linear_constraints`: **B (7) → A (5)**; `uvx radon cc src -s` now reports **all blocks A**
- Behaviour unchanged; `make fmt`, `make typecheck` (ty + mypy --strict), `make test` all pass — 96 passed, **100% coverage** (new helpers fully covered)

**done when:** `uvx radon cc src -s` shows no block ranking B or worse ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)