### PR TITLE
fix: revert premature 1.6.1 version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and entries are generated from [Conventional Commits](https://www.conventionalcommits.org).
 
-## [1.6.1] - 2026-06-17
+## [Unreleased]
 
 ### Maintenance
 - Chore(deps)(deps): bump the python-dependencies group with 4 updates (#475)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Main project metadata and configuration
 [project]
 name = "cvxrisk"
-version = "1.6.1"
+version = "1.6.0"
 description = "Simple riskengine for portfolio optimization"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -297,7 +297,7 @@ wheels = [
 
 [[package]]
 name = "cvxrisk"
-version = "1.6.1"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "clarabel" },


### PR DESCRIPTION
## Problem

`make all` fails on every branch at the `rhiza-test` target:

```
TestGitTagVersion::test_latest_tag_matches_pyproject_version
Latest git tag 'v1.6.0' (→ '1.6.0') does not match [project].version '1.6.1' in pyproject.toml
```

`pyproject.toml` was bumped `1.6.0 → 1.6.1` in a14755c (2026-06-17), but the `v1.6.1` tag was never created — the repo has been sitting mid-release since then. The latest tag is still `v1.6.0`, so the declared version and the tag have been out of sync for over a month.

## Fix

Revert the declared version to `1.6.0` so it matches the latest tag, rather than finishing the release.

- `pyproject.toml` — `version = "1.6.0"`
- `uv.lock` — matching `cvxrisk` version (edited in place; a full `uv lock` introduced unrelated `sys_platform != 'emscripten'` marker churn from a different local uv version, so that was left out)
- `CHANGELOG.md` — `## [1.6.1] - 2026-06-17` → `## [Unreleased]`, since those commits are merged but not in any tagged release. `CHANGELOG.md` is regenerated by `git-cliff` at release time, so the next real release folds them under its tag.

## Verification

`make all` is fully green — `fmt`, `deptry`, `test`, `docs-coverage`, `security`, `license`, `typecheck` (ty + mypy strict, 15 files), and `rhiza-test` at **32 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)