### PR TITLE
chore: update rhiza to v1.3.3

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,19 @@
+# Bandit configuration. This file — not the pre-commit hook's args — is the
+# single source of truth for bandit's scope, because it is the only part any
+# other runner can see. CodeFactor, IDE plugins and a contributor typing
+# `bandit -r .` all read `.bandit` and none of them read our hook args, so
+# scope kept in the args made every external analyser disagree with CI (#1493).
+#
+# Both spellings of each path are listed deliberately. Bandit matches an
+# exclude entry against the path string it is handed, and that string depends on
+# how it was invoked: a recursive `bandit -r .` discovers `./tests/foo.py`,
+# whereas pre-commit passes `tests/foo.py`. So `./tests` alone silently covers
+# only the recursive case and `tests` alone only the pre-commit case — a
+# one-spelling list looks correct and half-works. Verified in
+# tests/security/test_security_patterns.py, which runs bandit both ways.
+#
+# Note these are *added* to bandit's own defaults (.git, __pycache__, .tox,
+# .eggs, …), so those need no repeating here.
 [bandit]
+exclude = tests,./tests,.rhiza/tests,./.rhiza/tests,.venv,./.venv
 skips = B101

--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v1.3.3
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -26,5 +26,5 @@ on:
 
 jobs:
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v1.3.3
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v1.3.3
     secrets: inherit
     permissions:
       security-events: write   # Upload CodeQL results to code scanning

--- a/.github/workflows/rhiza_fuzzing.yml
+++ b/.github/workflows/rhiza_fuzzing.yml
@@ -34,7 +34,7 @@ permissions:
 
 jobs:
   fuzzing:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_fuzzing.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v1.3.3
     secrets: inherit

--- a/.github/workflows/rhiza_mutation.yml
+++ b/.github/workflows/rhiza_mutation.yml
@@ -42,7 +42,7 @@ jobs:
     # this repo sets the `MUTATION_ENABLED` variable to 'true'. Gating here in
     # the caller keeps it optional regardless of the pinned reusable workflow.
     if: ${{ vars.MUTATION_ENABLED == 'true' }}
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_mutation.yml@v1.3.3
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -36,7 +36,7 @@ permissions: read-all
 
 jobs:
   scorecard:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_scorecard.yml@v1.3.3
     secrets: inherit
     permissions:
       security-events: write   # Upload the SARIF results to code scanning

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.2
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v1.3.3
     secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.16.1'
+    rev: 'v0.16.2'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]
@@ -46,7 +46,7 @@ repos:
         args: ["--disable", "MD013"]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.4
+    rev: 0.38.0
     hooks:
       - id: check-renovate
         args: [ "--verbose" ]
@@ -68,15 +68,16 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
-        args: ["--ini", ".bandit", "--exclude", ".venv,tests,.rhiza/tests,.git,.pytest_cache"]
+        # Scope deliberately lives in .bandit, not here — see that file (#1493).
+        args: ["--ini", ".bandit"]
 
   - repo: https://github.com/betterleaks/betterleaks
-    rev: v1.7.3
+    rev: v1.7.4
     hooks:
       - id: betterleaks
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.1
+    rev: 0.12.3
     hooks:
       - id: uv-lock
 

--- a/.rhiza/make.d/marimo.mk
+++ b/.rhiza/make.d/marimo.mk
@@ -9,6 +9,16 @@ DEPTRY_FOLDERS += $(MARIMO_FOLDER)
 DEPTRY_IGNORE += --ignore DEP004
 endif
 
+# Exempt docutils from the licence gate in python.mk, on the same accumulator principle:
+# the bundle that brings a dependency in owns the exemption for it, rather than every
+# consumer rediscovering it. marimo depends on docutils, which is offered under a choice
+# of licences and reports all of them as one string -- "BSD License; GNU General Public
+# License (GPL); Public Domain". pip-licenses matches --fail-on against that string with
+# no notion of *or*, so now that the gate actually matches, `GPL` hits a package every
+# consumer of this bundle takes under BSD. Unconditional, unlike the deptry lines above:
+# the dependency arrives with marimo itself, not with a notebook folder.
+LICENSE_IGNORE_PACKAGES += docutils
+
 # Declare phony targets (they don't produce files)
 .PHONY: marimo-validate marimo
 

--- a/.rhiza/make.d/python.mk
+++ b/.rhiza/make.d/python.mk
@@ -29,8 +29,31 @@ UV_SYNC_ARGS ?= --all-extras --all-groups
 
 export UV_VENV_CLEAR := 1
 
-# Configurable list of licenses that fail the compliance scan (semicolon-separated)
+# Configurable list of licenses that fail the compliance scan (semicolon-separated).
+#
+# These are matched as *substrings* of the reported licence -- see `--partial-match`
+# in the `license` recipe. Without that flag pip-licenses compares against the whole
+# licence string, and `GPL` never equals a real classifier such as "GNU General
+# Public License v2 or later (GPLv2+)", so the gate passed with a GPL package
+# installed.
 LICENSE_FAIL_ON ?= GPL;LGPL;AGPL
+
+# Packages exempted from the scan by name, space-separated. Empty by default: an
+# exemption should be a deliberate, reviewable act -- in a project's own Makefile, or
+# in the bundle that owns the dependency -- not something this layer grants globally.
+# Two cases are legitimate, and `?=` plus `+=` makes it an accumulator for both:
+#
+#   1. A copyleft *development* dependency -- a reference implementation a differential
+#      test runs against -- never imported by the shipped package and never redistributed.
+#   2. A package offered under several licences at the reader's choice. pip-licenses
+#      reports the classifier list joined with "; " and has no notion of *or*, so
+#      `--partial-match` fires on the copyleft option even where a permissive one is
+#      taken. marimo.mk exempts docutils ("BSD License; GNU General Public License
+#      (GPL); Public Domain") for exactly this reason.
+#
+# Case 2 is the one to be careful with: check that a permissive option really is on
+# offer, rather than that the string merely looks long.
+LICENSE_IGNORE_PACKAGES ?=
 
 # Default directory for tests. Also read by the `tests` bundle's test.mk, which
 # requires this layer, so the two never disagree about where tests live.
@@ -145,9 +168,14 @@ deptry: ## deprecated alias for `deps`
 	@printf "${YELLOW}[WARN] \`make deptry\` is deprecated and will be removed; use \`make deps\`.${RESET}\n"
 	@$(MAKE) --no-print-directory deps
 
+# --ignore-packages takes one or more names and errors on a bare flag, so it is
+# omitted entirely when nothing is exempted.
+LICENSE_IGNORE_FLAG = $(if $(strip $(LICENSE_IGNORE_PACKAGES)),--ignore-packages $(strip $(LICENSE_IGNORE_PACKAGES)),)
+
 license: install ## run license compliance scan (fail on GPL, LGPL, AGPL)
 	@printf "${BLUE}[INFO] Running license compliance scan...${RESET}\n"
-	@${UV_BIN} run --with pip-licenses pip-licenses --fail-on="${LICENSE_FAIL_ON}"
+	@${UV_BIN} run --with pip-licenses pip-licenses \
+		--fail-on="${LICENSE_FAIL_ON}" --partial-match ${LICENSE_IGNORE_FLAG}
 
 ##@ Development and Testing
 

--- a/.rhiza/template.lock
+++ b/.rhiza/template.lock
@@ -1,7 +1,7 @@
-sha: 996d5df684d8967907d883e43e0d28376b0ac140
+sha: ac4d27b015edf70b47f0454b8251ac618f9d2bda
 repo: jebel-quant/rhiza
 host: github
-ref: v1.3.2
+ref: v1.3.3
 include: []
 exclude: []
 templates:
@@ -76,5 +76,5 @@ files:
 - pytest.ini
 - ruff.toml
 - tests/test_rhiza_packaging.py
-synced_at: '2026-08-04T17:53:26Z'
+synced_at: '2026-08-11T09:14:00Z'
 strategy: merge

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v1.3.2"
+ref: "v1.3.3"
 
 profiles:
   - github-project

--- a/docs/development/TESTS.md
+++ b/docs/development/TESTS.md
@@ -202,6 +202,7 @@ Example:
 ```python
 from hypothesis import given, strategies as st, example
 
+
 @given(version=st.from_regex(r"^\d+\.\d+\.\d+$", fullmatch=True))
 @example(version="0.0.0")  # Test specific edge case
 def test_version_parsing(version):


### PR DESCRIPTION
Template sync from `jebel-quant/rhiza`: `v1.3.2` → `v1.3.3`.

- 14 template-owned files changed (plus `.rhiza/template.yml` and `.rhiza/template.lock`).
- No merge conflicts — sync completed cleanly.
- Nothing left unstaged: no repo-owned file was touched.

No gates were run — run `/rhiza:quality` for a scorecard.
