### PR TITLE
docs: point documentation links at the site root

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ print(model.parameter["R"].value.shape)
 ```
 ## 📚 Documentation
 
-For more detailed documentation and examples, visit our [documentation site](https://www.cvxgrp.org/cvxrisk/book/).
+For more detailed documentation and examples, visit our [documentation site](https://www.cvxgrp.org/cvxrisk/).
 
 ## 🛠️ Development
 

--- a/introduction.md
+++ b/introduction.md
@@ -264,7 +264,7 @@ where $\Sigma_f$ is the covariance matrix of the factors and $Var(\epsilon_i)$ i
 
 ## Further Reading
 
-For more detailed documentation and examples, visit the [cvxrisk documentation site](http://www.cvxgrp.org/cvxrisk/book).
+For more detailed documentation and examples, visit the [cvxrisk documentation site](https://www.cvxgrp.org/cvxrisk/).
 
 To learn more about convex optimization and its applications in finance, check out:
 


### PR DESCRIPTION
Fixes the `Check links in README.md` job of the weekly workflow ([run 32705730225](https://github.com/cvxgrp/cvxrisk/actions/runs/32705730225)).

## Problem

`https://www.cvxgrp.org/cvxrisk/book/` returns **404**. The published docs site no longer has a `/book/` path — notebooks are served at `/cvxrisk/notebooks/*.html` per `mkdocs.yml`.

## Change

Both documentation links now point at the site root, which returns 200:

- `README.md:189`
- `introduction.md:267` — same stale path, and it was `http://` rather than `https://`

## Verification

Re-checked every hyperlink in both files with `curl -L`: all 15 return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)